### PR TITLE
DD-1532: 4th batch of unit test

### DIFF
--- a/src/main/java/nl/knaw/dans/layerstore/LayeredItemStore.java
+++ b/src/main/java/nl/knaw/dans/layerstore/LayeredItemStore.java
@@ -257,8 +257,8 @@ public class LayeredItemStore implements ItemStore {
                 layerPaths.computeIfAbsent(layerId, k -> new ArrayList<>()).add(path);
             }
         }
-        // Delete the files in each layer
-        for (var entry : layerPaths.entrySet()) {
+        // Delete the files in each layer, assuming old layers are closed
+        for (var entry : layerPaths.entrySet().stream().sorted().toList()) {
             var layer = layerManager.getLayer(entry.getKey());
             if (layer.isOpen()) {
                 layer.deleteFiles(entry.getValue());

--- a/src/test/java/nl/knaw/dans/layerstore/AbstractTestWithTestDir.java
+++ b/src/test/java/nl/knaw/dans/layerstore/AbstractTestWithTestDir.java
@@ -18,12 +18,8 @@ package nl.knaw.dans.layerstore;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * A test class that creates a test directory for each test method.
@@ -44,14 +40,6 @@ public abstract class AbstractTestWithTestDir {
         }
     }
 
-    public static ByteArrayInputStream toInputStream(String testContent) {
-        return new ByteArrayInputStream(toBytes(testContent));
-    }
-
-    public static byte[] toBytes(String testContent) {
-        return testContent.getBytes(StandardCharsets.UTF_8);
-    }
-
     public void createEmptyStagingDirFiles(String... paths) {
         for (String path : paths) {
             var message = "Could not create staging file: " + path;
@@ -65,14 +53,5 @@ public abstract class AbstractTestWithTestDir {
                 throw new RuntimeException(message, e);
             }
         }
-    }
-
-    /**
-     * Assume that a bug is not yet fixed. This allows to skip assertions while still showing the code covered by the test.
-        *
-        * @param message the message to display
-        */
-    public void assumeNotYetFixed (String message) {
-        assumeTrue(false, message);
     }
 }

--- a/src/test/java/nl/knaw/dans/layerstore/DirectExecutor.java
+++ b/src/test/java/nl/knaw/dans/layerstore/DirectExecutor.java
@@ -1,0 +1,11 @@
+package nl.knaw.dans.layerstore;
+
+import java.util.concurrent.Executor;
+
+class DirectExecutor implements Executor {
+
+    @Override
+    public void execute(Runnable runnable) {
+        runnable.run();
+    }
+}

--- a/src/test/java/nl/knaw/dans/layerstore/DirectExecutor.java
+++ b/src/test/java/nl/knaw/dans/layerstore/DirectExecutor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.layerstore;
 
 import java.util.concurrent.Executor;

--- a/src/test/java/nl/knaw/dans/layerstore/LayerArchiveTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerArchiveTest.java
@@ -21,14 +21,15 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class LayerArchiveTest extends AbstractTestWithTestDir {
     @Test
     public void throws_IllegalStateException_when_layer_is_closed() {
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
-        assertThrows(IllegalStateException.class, layer::archive);
+        assertThatThrownBy(layer::archive)
+            .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
@@ -37,7 +38,8 @@ public class LayerArchiveTest extends AbstractTestWithTestDir {
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         layer.close();
         layer.archive();
-        assertThrows(IllegalStateException.class, layer::archive);
+        assertThatThrownBy(layer::archive)
+            .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
@@ -45,10 +47,11 @@ public class LayerArchiveTest extends AbstractTestWithTestDir {
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         layer.close();
 
-        var cause = assertThrows(RuntimeException.class, layer::archive).getCause();
-        assertThat(cause).isInstanceOf(NoSuchFileException.class);
-        // misleading message: the problem is that the LayerArchiveTest dir does not exist
-        assertThat(cause.getMessage()).isEqualTo("target/test/LayerArchiveTest/layer_archive/test.zip");
+        assertThatThrownBy(layer::archive)
+            .isInstanceOf(RuntimeException.class)
+            .hasRootCauseInstanceOf(NoSuchFileException.class)
+            .hasRootCauseMessage("target/test/LayerArchiveTest/layer_archive/test.zip");
+        // misleading message: the actual problem is that the LayerArchiveTest dir does not exist
     }
 
     @Test

--- a/src/test/java/nl/knaw/dans/layerstore/LayerArchiveTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerArchiveTest.java
@@ -27,33 +27,34 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class LayerArchiveTest extends AbstractTestWithTestDir {
     @Test
     public void throws_IllegalStateException_when_layer_is_closed() {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         assertThrows(IllegalStateException.class, layer::archive);
     }
 
     @Test
     public void throws_IllegalStateException_when_layer_is_already_archived() throws IOException {
-        Files.createDirectories(testDir);
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        Files.createDirectories(archiveDir);
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         layer.close();
         layer.archive();
         assertThrows(IllegalStateException.class, layer::archive);
     }
 
     @Test
-    public void throws_RuntimeException_caused_by_an_IOException() {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+    public void throws_RuntimeException_caused_by_an_IOException() throws IOException {
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         layer.close();
 
         var cause = assertThrows(RuntimeException.class, layer::archive).getCause();
         assertThat(cause).isInstanceOf(NoSuchFileException.class);
         // misleading message: the problem is that the LayerArchiveTest dir does not exist
-        assertThat(cause.getMessage()).isEqualTo("target/test/LayerArchiveTest/test.zip");
+        assertThat(cause.getMessage()).isEqualTo("target/test/LayerArchiveTest/layer_archive/test.zip");
     }
 
     @Test
-    public void removes_staging_dir() {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+    public void removes_staging_dir() throws IOException {
+        Files.createDirectories(archiveDir);
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         assertThat(stagingDir).doesNotExist();
         createEmptyStagingDirFiles("path/to/file1");
         assertThat(stagingDir).exists();

--- a/src/test/java/nl/knaw/dans/layerstore/LayerArchiveTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerArchiveTest.java
@@ -43,7 +43,7 @@ public class LayerArchiveTest extends AbstractTestWithTestDir {
     }
 
     @Test
-    public void throws_RuntimeException_caused_by_an_IOException() throws IOException {
+    public void throws_RuntimeException_caused_by_an_IOException() {
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         layer.close();
 

--- a/src/test/java/nl/knaw/dans/layerstore/LayerCloseTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerCloseTest.java
@@ -18,7 +18,7 @@ package nl.knaw.dans.layerstore;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 public class LayerCloseTest extends AbstractTestWithTestDir {
 
@@ -26,7 +26,8 @@ public class LayerCloseTest extends AbstractTestWithTestDir {
     public void throws_IllegalStateException_when_layer_is_already_closed() {
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         layer.close();
-        assertThrows(IllegalStateException.class, layer::close);
+        assertThatThrownBy(layer::close)
+            .isInstanceOf(IllegalStateException.class);
     }
 
     @Test

--- a/src/test/java/nl/knaw/dans/layerstore/LayerCloseTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerCloseTest.java
@@ -24,14 +24,14 @@ public class LayerCloseTest extends AbstractTestWithTestDir {
 
     @Test
     public void throws_IllegalStateException_when_layer_is_already_closed() {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         layer.close();
         assertThrows(IllegalStateException.class, layer::close);
     }
 
     @Test
     public void should_close_layer() {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         layer.close();
         assertThat(layer.isClosed()).isTrue();
     }

--- a/src/test/java/nl/knaw/dans/layerstore/LayerCreateDirectoryTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerCreateDirectoryTest.java
@@ -23,14 +23,14 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 public class LayerCreateDirectoryTest extends AbstractTestWithTestDir {
     @Test
     public void should_create_directories_in_staging_dir_if_layer_is_open() throws Exception {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         layer.createDirectory("path/to/directory");
         assertThat(stagingDir.resolve("path/to/directory")).exists();
     }
 
     @Test
     public void should_throw_IllegalStateException_if_layer_is_closed() {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         layer.close();
         assertThatThrownBy(() -> layer.createDirectory("path/to/directory"))
             .isInstanceOf(IllegalStateException.class)
@@ -39,7 +39,7 @@ public class LayerCreateDirectoryTest extends AbstractTestWithTestDir {
 
     @Test
     public void should_throw_IllegalArgumentException_if_path_is_null() {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         assertThatThrownBy(() -> layer.createDirectory(null))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("Path cannot be null");
@@ -47,7 +47,7 @@ public class LayerCreateDirectoryTest extends AbstractTestWithTestDir {
 
     @Test
     public void should_throw_IllegalArgumentException_if_path_is_blank() {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         assertThatThrownBy(() -> layer.createDirectory(" "))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("Path cannot be blank");
@@ -55,14 +55,14 @@ public class LayerCreateDirectoryTest extends AbstractTestWithTestDir {
 
     @Test
     public void should_create_staging_dir_if_path_is_empty() throws Exception {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         layer.createDirectory("");
         assertThat(stagingDir).exists();
     }
 
     @Test
     public void should_throw_IllegalArgumentException_if_path_is_not_a_valid_path() {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         assertThatThrownBy(() -> layer.createDirectory("path/to/../../../directory"))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("Path is outside staging directory");

--- a/src/test/java/nl/knaw/dans/layerstore/LayerDatabaseListDirectoryTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerDatabaseListDirectoryTest.java
@@ -114,7 +114,7 @@ public class LayerDatabaseListDirectoryTest extends AbstractLayerDatabaseTest {
     }
 
     @Test
-    public void should_throw_NotDirectoryException_when_path_is_not_a_directory() throws Exception {
+    public void should_throw_NotDirectoryException_when_path_is_not_a_directory() {
         addToDb(1L, "dir", Type.Directory);
         addToDb(1L, "dir/file", Type.File);
         assertThatThrownBy(() -> dao.listDirectory("dir/file"))
@@ -123,7 +123,7 @@ public class LayerDatabaseListDirectoryTest extends AbstractLayerDatabaseTest {
     }
 
     @Test
-    public void should_throw_NoSuchFileException_when_path_does_not_exist() throws Exception {
+    public void should_throw_NoSuchFileException_when_path_does_not_exist() {
         addToDb(1L, "dir", Type.Directory);
         addToDb(1L, "dir/file", Type.File);
         assertThatThrownBy(() -> dao.listDirectory("dir/does-not-exist"))

--- a/src/test/java/nl/knaw/dans/layerstore/LayerDeleteDirectoryTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerDeleteDirectoryTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 public class LayerDeleteDirectoryTest extends AbstractTestWithTestDir {
     @Test
     public void should_delete_directory_in_staging_dir_when_layer_is_open() throws Exception {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         createEmptyStagingDirFiles("path/to/file1", "path/to/file2");
         createEmptyStagingDirFiles("path/too/file1", "path/too/file2");
 
@@ -42,7 +42,7 @@ public class LayerDeleteDirectoryTest extends AbstractTestWithTestDir {
 
     @Test
     public void should_throw_IllegalStateException_when_layer_is_closed() {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         // Create directories with files in it
         createEmptyStagingDirFiles("path/to/file1", "path/to/file2");
         createEmptyStagingDirFiles("path/too/file1", "path/too/file2");
@@ -55,7 +55,7 @@ public class LayerDeleteDirectoryTest extends AbstractTestWithTestDir {
 
     @Test
     public void should_throw_IllegalArgumentException_when_path_is_null() {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         assertThatThrownBy(() -> layer.deleteDirectory(null))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("Path cannot be null");

--- a/src/test/java/nl/knaw/dans/layerstore/LayerDeleteFilesTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerDeleteFilesTest.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 public class LayerDeleteFilesTest extends AbstractTestWithTestDir {
     @Test
     public void should_delete_files_in_staging_dir_if_layer_is_open() throws Exception {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         createEmptyStagingDirFiles("path/to/file1", "path/to/file2");
 
         layer.deleteFiles(List.of("path/to/file1", "path/to/file2"));
@@ -36,7 +36,7 @@ public class LayerDeleteFilesTest extends AbstractTestWithTestDir {
 
     @Test
     public void should_throw_IllegalStateException_if_layer_is_closed() {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         layer.close();
         assertThatThrownBy(() -> layer.deleteFiles(List.of("path/to/file1", "path/to/file2")))
             .isInstanceOf(IllegalStateException.class)
@@ -45,7 +45,7 @@ public class LayerDeleteFilesTest extends AbstractTestWithTestDir {
 
     @Test
     public void should_throw_IllegalArgumentException_if_path_is_null() {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         assertThatThrownBy(() -> layer.deleteFiles(null))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("Paths cannot be null");
@@ -53,7 +53,7 @@ public class LayerDeleteFilesTest extends AbstractTestWithTestDir {
 
     @Test
     public void should_throw_IllegalArgumentException_if_path_contains_null() throws Exception {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
 
         if (!stagingDir.resolve("path/to").toFile().mkdirs() ||
             !stagingDir.resolve("path/to/file1").toFile().createNewFile()) {

--- a/src/test/java/nl/knaw/dans/layerstore/LayerFileExistsTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerFileExistsTest.java
@@ -17,13 +17,15 @@ package nl.knaw.dans.layerstore;
 
 import org.junit.jupiter.api.Test;
 
+import java.nio.file.Files;
+
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 public class LayerFileExistsTest extends AbstractTestWithTestDir {
 
     @Test
     public void should_return_true_if_file_exists() throws Exception {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         createEmptyStagingDirFiles("path/to/file1", "path/to/file2");
 
         assertThat(layer.fileExists("path/to/file1")).isTrue();
@@ -31,7 +33,8 @@ public class LayerFileExistsTest extends AbstractTestWithTestDir {
 
     @Test
     public void should_return_true_if_file_exists_in_archived_layer() throws Exception {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        Files.createDirectories(archiveDir);
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         createEmptyStagingDirFiles("path/to/file1", "path/to/file2");
 
         assertThat(stagingDir.resolve("path/to/file1").toFile()).exists();
@@ -41,18 +44,19 @@ public class LayerFileExistsTest extends AbstractTestWithTestDir {
 
         assertThat(layer.fileExists("path/to/file1")).isTrue();
         assertThat(stagingDir.resolve("path/to/file1").toFile()).doesNotExist();
-        assertThat(testDir.resolve("test.zip").toFile()).exists();
+        assertThat(archiveDir.resolve("test.zip").toFile()).exists();
         assertThat(layer.isArchived()).isTrue();
     }
 
     @Test
     public void should_return_false_if_file_existed_in_destroyed_archived_layer() throws Exception {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        Files.createDirectories(archiveDir);
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         createEmptyStagingDirFiles("path/to/file1", "path/to/file2");
 
         layer.close();
         layer.archive();
-        if (!testDir.resolve("test.zip").toFile().delete()) {
+        if (!archiveDir.resolve("test.zip").toFile().delete()) {
             throw new Exception("Could not delete test.zip");
         }
         assertThat(layer.fileExists("path/to/file1")).isFalse();
@@ -60,7 +64,7 @@ public class LayerFileExistsTest extends AbstractTestWithTestDir {
 
     @Test
     public void should_return_false_if_file_does_not_exist() throws Exception {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         createEmptyStagingDirFiles("path/to/file1", "path/to/file2");
 
         assertThat(layer.fileExists("path/to/file3")).isFalse();

--- a/src/test/java/nl/knaw/dans/layerstore/LayerGetSizeInBytesTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerGetSizeInBytesTest.java
@@ -17,6 +17,9 @@ package nl.knaw.dans.layerstore;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.nio.file.Files;
+
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
@@ -24,7 +27,7 @@ public class LayerGetSizeInBytesTest extends AbstractTestWithTestDir {
 
     @Test
     public void should_add_up_file_sizes() throws Exception {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         layer.writeFile("test.txt", toInputStream("Hello world!"));
         layer.createDirectory("path/to");
         layer.writeFile("path/to/other.txt", toInputStream("Whatever"));
@@ -34,7 +37,7 @@ public class LayerGetSizeInBytesTest extends AbstractTestWithTestDir {
 
     @Test
     public void should_throw_IllegalStateException_when_layer_is_closed() {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         layer.close();
 
         assertThatThrownBy(layer::getSizeInBytes).

--- a/src/test/java/nl/knaw/dans/layerstore/LayerGetSizeInBytesTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerGetSizeInBytesTest.java
@@ -17,6 +17,7 @@ package nl.knaw.dans.layerstore;
 
 import org.junit.jupiter.api.Test;
 
+import static nl.knaw.dans.layerstore.TestUtils.toInputStream;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 

--- a/src/test/java/nl/knaw/dans/layerstore/LayerGetSizeInBytesTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerGetSizeInBytesTest.java
@@ -17,9 +17,6 @@ package nl.knaw.dans.layerstore;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.nio.file.Files;
-
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 

--- a/src/test/java/nl/knaw/dans/layerstore/LayerGetSizeInBytesTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerGetSizeInBytesTest.java
@@ -17,7 +17,8 @@ package nl.knaw.dans.layerstore;
 
 import org.junit.jupiter.api.Test;
 
-import static nl.knaw.dans.layerstore.TestUtils.toInputStream;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
@@ -26,9 +27,9 @@ public class LayerGetSizeInBytesTest extends AbstractTestWithTestDir {
     @Test
     public void should_add_up_file_sizes() throws Exception {
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
-        layer.writeFile("test.txt", toInputStream("Hello world!"));
+        layer.writeFile("test.txt", toInputStream("Hello world!", UTF_8));
         layer.createDirectory("path/to");
-        layer.writeFile("path/to/other.txt", toInputStream("Whatever"));
+        layer.writeFile("path/to/other.txt", toInputStream("Whatever", UTF_8));
 
         assertThat(layer.getSizeInBytes()).isEqualTo(20L);
     }

--- a/src/test/java/nl/knaw/dans/layerstore/LayerManagerConstructorTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerManagerConstructorTest.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 public class LayerManagerConstructorTest extends AbstractLayerDatabaseTest {

--- a/src/test/java/nl/knaw/dans/layerstore/LayerManagerGetLayerTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerManagerGetLayerTest.java
@@ -21,6 +21,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 
 import static java.lang.Thread.sleep;
+import static nl.knaw.dans.layerstore.TestUtils.assumeNotYetFixed;
+import static nl.knaw.dans.layerstore.TestUtils.toInputStream;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;

--- a/src/test/java/nl/knaw/dans/layerstore/LayerManagerGetLayerTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerManagerGetLayerTest.java
@@ -21,8 +21,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 
 import static java.lang.Thread.sleep;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static nl.knaw.dans.layerstore.TestUtils.assumeNotYetFixed;
-import static nl.knaw.dans.layerstore.TestUtils.toInputStream;
+import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
@@ -61,7 +62,7 @@ public class LayerManagerGetLayerTest extends AbstractTestWithTestDir {
         // Given
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
         var topLayer = layerManager.getTopLayer();
-        topLayer.writeFile("test.txt", toInputStream("Hello world!"));
+        topLayer.writeFile("test.txt", toInputStream("Hello world!", UTF_8));
 
         // When
         var layer = layerManager.getLayer(topLayer.getId());
@@ -112,7 +113,7 @@ public class LayerManagerGetLayerTest extends AbstractTestWithTestDir {
         // Given
         Files.createDirectories(archiveDir);
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
-        layerManager.getTopLayer().writeFile("test.txt", toInputStream("Hello world!"));
+        layerManager.getTopLayer().writeFile("test.txt", toInputStream("Hello world!", UTF_8));
         Layer initialLayer = layerManager.getTopLayer();
         var initialLayerId = initialLayer.getId();
         sleep(1L); // to make sure to get a layer with another time stamp

--- a/src/test/java/nl/knaw/dans/layerstore/LayerManagerGetLayerTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerManagerGetLayerTest.java
@@ -25,7 +25,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static nl.knaw.dans.layerstore.TestUtils.assumeNotYetFixed;
 import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 

--- a/src/test/java/nl/knaw/dans/layerstore/LayerManagerNewTopLayerTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerManagerNewTopLayerTest.java
@@ -15,5 +15,114 @@
  */
 package nl.knaw.dans.layerstore;
 
-public class LayerManagerNewTopLayerTest {
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.util.concurrent.Executor;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class LayerManagerNewTopLayerTest extends AbstractTestWithTestDir {
+    private ListAppender<ILoggingEvent> listAppender;
+
+    private static class ThrowingArchiveProvider implements ArchiveProvider {
+
+        @Override
+        public Archive createArchive(String path) {
+            return new Archive() {
+
+                @Override
+                public InputStream readFile(String filePath) {
+                    return null;
+                }
+
+                @Override
+                public void unarchiveTo(Path stagingDir) {
+
+                }
+
+                @Override
+                public void archiveFrom(Path stagingDir) {
+                    throw new RuntimeException("archiveFrom failed");
+                }
+
+                @Override
+                public boolean isArchived() {
+                    return false;
+                }
+
+                @Override
+                public boolean fileExists(String filePath) {
+                    return false;
+                }
+            };
+        }
+
+        @Override
+        public boolean exists(String path) {
+            return false;
+        }
+    }
+
+    private static class DirectExecutor implements Executor {
+
+        @Override
+        public void execute(Runnable runnable) {
+            runnable.run();
+        }
+    }
+
+    @BeforeEach
+    public void captureLog() {
+        var logger = (Logger) LoggerFactory.getLogger(LayerManagerImpl.class);
+        listAppender = new ListAppender<>();
+        listAppender.start();
+        logger.setLevel(Level.ERROR);
+        logger.addAppender(listAppender);
+    }
+
+    private static ByteArrayOutputStream captureStdout() {
+        var outContent = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outContent));
+        return outContent;
+    }
+
+    @Test
+    public void should_log_an_archive_failure() throws IOException {
+
+        var layerManager = new LayerManagerImpl(stagingDir, new ThrowingArchiveProvider(), new DirectExecutor());
+        var initialTopLayerId = layerManager.getTopLayer().getId();
+
+        var outContent = captureStdout();
+
+        // Run the method under test
+        assertThatThrownBy(layerManager::newTopLayer)
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage("java.lang.RuntimeException: archiveFrom failed");
+
+        // Check the logs
+        var loggingEvent = listAppender.list.get(0);
+        assertThat(loggingEvent.getLevel()).isEqualTo(Level.ERROR);
+        assertThat(loggingEvent.getFormattedMessage())
+            .isEqualTo("Error archiving layer with id " + initialTopLayerId);
+
+        // Check stdout, different formats when running standalone or in a suite
+        var contentString = outContent.toString();
+        assertThat(contentString).contains("Error archiving layer with id " + initialTopLayerId);
+        assertThat(contentString).contains("java.lang.RuntimeException: archiveFrom failed");
+        assertThat(contentString).contains("at nl.knaw.dans.layerstore.LayerManagerNewTopLayerTest");
+    }
+
+    // the method is also involved in tests for other LayerManagerImpl methods and LayeredItemStore methods
 }

--- a/src/test/java/nl/knaw/dans/layerstore/LayerManagerNewTopLayerTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerManagerNewTopLayerTest.java
@@ -16,17 +16,12 @@
 package nl.knaw.dans.layerstore;
 
 import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.read.ListAppender;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.PrintStream;
 
+import static nl.knaw.dans.layerstore.TestUtils.captureLog;
+import static nl.knaw.dans.layerstore.TestUtils.captureStdout;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -35,22 +30,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class LayerManagerNewTopLayerTest extends AbstractTestWithTestDir {
-    private ListAppender<ILoggingEvent> listAppender;
-
-    @BeforeEach
-    public void captureLog() {
-        var logger = (Logger) LoggerFactory.getLogger(LayerManagerImpl.class);
-        listAppender = new ListAppender<>();
-        listAppender.start();
-        logger.setLevel(Level.ERROR);
-        logger.addAppender(listAppender);
-    }
-
-    private static ByteArrayOutputStream captureStdout() {
-        var outContent = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(outContent));
-        return outContent;
-    }
 
     @Test
     public void should_log_an_archive_failure() throws IOException {
@@ -63,7 +42,7 @@ public class LayerManagerNewTopLayerTest extends AbstractTestWithTestDir {
             .thenReturn(mockedArchive);
 
         var outContent = captureStdout();
-
+        var listAppender = captureLog();
 
         var layerManager = new LayerManagerImpl(stagingDir, mockedArchiveProvider, new DirectExecutor());
         var initialTopLayerId = layerManager.getTopLayer().getId();

--- a/src/test/java/nl/knaw/dans/layerstore/LayerManagerNewTopLayerTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerManagerNewTopLayerTest.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.nio.file.Path;
-import java.util.concurrent.Executor;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -72,14 +71,6 @@ public class LayerManagerNewTopLayerTest extends AbstractTestWithTestDir {
         @Override
         public boolean exists(String path) {
             return false;
-        }
-    }
-
-    private static class DirectExecutor implements Executor {
-
-        @Override
-        public void execute(Runnable runnable) {
-            runnable.run();
         }
     }
 

--- a/src/test/java/nl/knaw/dans/layerstore/LayerMoveDirectoryInternalTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerMoveDirectoryInternalTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 public class LayerMoveDirectoryInternalTest extends AbstractTestWithTestDir {
     @Test
     public void should_move_directory_from_staging_dir_to_staging_dir_if_layer_is_open() throws Exception {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         createEmptyStagingDirFiles("path/to/file1", "path/to/file2");
 
         layer.moveDirectoryInternal("path/to/", "path/too/");
@@ -35,7 +35,7 @@ public class LayerMoveDirectoryInternalTest extends AbstractTestWithTestDir {
 
     @Test
     public void should_throw_IllegalStateException_when_layer_is_closed() throws Exception {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         // Create a directory with files in it
         if (!stagingDir.resolve("path/to").toFile().mkdirs() ||
             !stagingDir.resolve("path/to/file1").toFile().createNewFile() ||
@@ -51,7 +51,7 @@ public class LayerMoveDirectoryInternalTest extends AbstractTestWithTestDir {
 
     @Test
     public void should_throw_IllegalArgumentException_if_source_is_outside_staging_dir() {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         assertThatThrownBy(() -> layer.moveDirectoryInternal("../path/to/", "path/too/"))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("Path is outside staging directory");
@@ -59,7 +59,7 @@ public class LayerMoveDirectoryInternalTest extends AbstractTestWithTestDir {
 
     @Test
     public void should_throw_IllegalArgumentException_if_destination_is_outside_staging_dir() {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         assertThatThrownBy(() -> layer.moveDirectoryInternal("path/to/", "../path/too/"))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("Path is outside staging directory");

--- a/src/test/java/nl/knaw/dans/layerstore/LayerMoveDirectoryIntoTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerMoveDirectoryIntoTest.java
@@ -25,7 +25,7 @@ public class LayerMoveDirectoryIntoTest extends AbstractTestWithTestDir {
     public void should_move_directory_into_staging_dir_when_layer_is_open() throws Exception {
         var inputDir = testDir.resolve("input-roundtrip");
 
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
 
         // Create some files in the input directory
         if (!inputDir.resolve("path/to").toFile().mkdirs() ||
@@ -55,7 +55,7 @@ public class LayerMoveDirectoryIntoTest extends AbstractTestWithTestDir {
     public void should_throw_IllegalStateException_when_layer_is_closed() throws Exception {
         var inputDir = testDir.resolve("input-roundtrip");
 
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
 
         // Create some files in the input directory
         if (!inputDir.resolve("path/to").toFile().mkdirs() ||

--- a/src/test/java/nl/knaw/dans/layerstore/LayerReadFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerReadFileTest.java
@@ -20,13 +20,14 @@ import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 public class LayerReadFileTest extends AbstractTestWithTestDir {
     @Test
     public void should_read_file_from_staging_dir_if_layer_is_open() throws Exception {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         var testContents = "test file";
         FileUtils.write(stagingDir.resolve("path/to/file1").toFile(), testContents, StandardCharsets.UTF_8);
 
@@ -38,7 +39,7 @@ public class LayerReadFileTest extends AbstractTestWithTestDir {
 
     @Test
     public void should_read_file_from_staging_dir_if_layer_is_closed_but_not_archived() throws Exception {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         var testContents = "test file";
         FileUtils.write(stagingDir.resolve("path/to/file1").toFile(), testContents, StandardCharsets.UTF_8);
         layer.close();
@@ -51,7 +52,8 @@ public class LayerReadFileTest extends AbstractTestWithTestDir {
 
     @Test
     public void should_read_file_from_archive_if_layer_is_closed_and_archived() throws Exception {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        Files.createDirectories(archiveDir);
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         var testContents = "test file";
         FileUtils.write(stagingDir.resolve("path/to/file1").toFile(), testContents, StandardCharsets.UTF_8);
         layer.close();

--- a/src/test/java/nl/knaw/dans/layerstore/LayerReopenTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerReopenTest.java
@@ -17,6 +17,9 @@ package nl.knaw.dans.layerstore;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.nio.file.Files;
+
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -27,7 +30,7 @@ public class LayerReopenTest extends AbstractTestWithTestDir {
 
     @Test
     public void should_throw_not_archived() {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         assertTrue(layer.isOpen());
         layer.close();
         assertFalse(layer.isOpen());
@@ -38,15 +41,16 @@ public class LayerReopenTest extends AbstractTestWithTestDir {
 
     @Test
     public void should_throw_must_be_closed() {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         assertThatThrownBy(layer::reopen).
             isInstanceOf(IllegalStateException.class)
             .hasMessage("Layer is open, but must be closed for this operation");
     }
 
     @Test
-    public void should_restore_archived_files() {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+    public void should_restore_archived_files() throws IOException {
+        Files.createDirectories(archiveDir);
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         createEmptyStagingDirFiles("path/to/file1", "path/to/file2");
         layer.close();
         layer.archive();

--- a/src/test/java/nl/knaw/dans/layerstore/LayerWriteFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerWriteFileTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 public class LayerWriteFileTest extends AbstractTestWithTestDir {
     @Test
     public void should_write_file_to_staging_dir_when_layer_is_open() throws Exception {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
 
         // Write a file to the layer
         var testContent = "Hello world!";
@@ -38,7 +38,7 @@ public class LayerWriteFileTest extends AbstractTestWithTestDir {
 
     @Test
     public void should_throw_IllegalStateException_when_layer_is_closed() {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(testDir.resolve("test.zip")));
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         layer.close();
 
         assertThatThrownBy(() -> layer.writeFile("whatever.txt", toInputStream("whatever"))).

--- a/src/test/java/nl/knaw/dans/layerstore/LayerWriteFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerWriteFileTest.java
@@ -19,7 +19,8 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 
-import static nl.knaw.dans.layerstore.TestUtils.toInputStream;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
@@ -30,7 +31,7 @@ public class LayerWriteFileTest extends AbstractTestWithTestDir {
 
         // Write a file to the layer
         var testContent = "Hello world!";
-        layer.writeFile("test.txt", toInputStream(testContent));
+        layer.writeFile("test.txt", toInputStream(testContent, UTF_8));
 
         // Verify that the file is written to the staging dir and has
         assertThat(stagingDir.resolve("test.txt")).exists();
@@ -42,7 +43,7 @@ public class LayerWriteFileTest extends AbstractTestWithTestDir {
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         layer.close();
 
-        assertThatThrownBy(() -> layer.writeFile("whatever.txt", toInputStream("whatever"))).
+        assertThatThrownBy(() -> layer.writeFile("whatever.txt", toInputStream("whatever", UTF_8))).
             isInstanceOf(IllegalStateException.class)
             .hasMessage("Layer is closed, but must be open for this operation");
     }

--- a/src/test/java/nl/knaw/dans/layerstore/LayerWriteFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerWriteFileTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 
+import static nl.knaw.dans.layerstore.TestUtils.toInputStream;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreCopyDirectoryOutOfTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreCopyDirectoryOutOfTest.java
@@ -23,6 +23,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
+import static nl.knaw.dans.layerstore.TestUtils.toInputStream;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 public class LayeredItemStoreCopyDirectoryOutOfTest extends AbstractLayerDatabaseTest {

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreCopyDirectoryOutOfTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreCopyDirectoryOutOfTest.java
@@ -23,7 +23,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
-import static nl.knaw.dans.layerstore.TestUtils.toInputStream;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 public class LayeredItemStoreCopyDirectoryOutOfTest extends AbstractLayerDatabaseTest {
@@ -39,8 +40,8 @@ public class LayeredItemStoreCopyDirectoryOutOfTest extends AbstractLayerDatabas
         var layeredStore = new LayeredItemStore(dao, layerManager);
         Files.createDirectories(archiveDir);
         layeredStore.createDirectory("a/b/c/d/e");
-        layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!"));
-        layeredStore.writeFile("a/b/c/test2.txt", toInputStream("Hello again!"));
+        layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!", UTF_8));
+        layeredStore.writeFile("a/b/c/test2.txt", toInputStream("Hello again!", UTF_8));
         var destination = testDir.resolve("copy");
 
         layeredStore.copyDirectoryOutOf("a/b/c/d", destination);
@@ -55,8 +56,8 @@ public class LayeredItemStoreCopyDirectoryOutOfTest extends AbstractLayerDatabas
         var layeredStore = new LayeredItemStore(dao, layerManager);
         Files.createDirectories(archiveDir);
         layeredStore.createDirectory("a/b/c/d/e");
-        layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!"));
-        layeredStore.writeFile("a/b/c/test2.txt", toInputStream("Hello again!"));
+        layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!", UTF_8));
+        layeredStore.writeFile("a/b/c/test2.txt", toInputStream("Hello again!", UTF_8));
         var destination = testDir.resolve("copy");
         FileUtils.writeLines(destination.resolve("a/b/c/d/test1.txt").toFile(), List.of("Hello there!"));
 
@@ -71,8 +72,8 @@ public class LayeredItemStoreCopyDirectoryOutOfTest extends AbstractLayerDatabas
         var layeredStore = new LayeredItemStore(dao, layerManager);
         Files.createDirectories(archiveDir);
         layeredStore.createDirectory("a/b/c/d/e");
-        layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!"));
-        layeredStore.writeFile("a/b/c/test2.txt", toInputStream("Hello again!"));
+        layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!", UTF_8));
+        layeredStore.writeFile("a/b/c/test2.txt", toInputStream("Hello again!", UTF_8));
         Path destination = testDir.resolve("copy");
 
         layeredStore.copyDirectoryOutOf("a/b/c/d/e", destination);
@@ -86,9 +87,9 @@ public class LayeredItemStoreCopyDirectoryOutOfTest extends AbstractLayerDatabas
         var layeredStore = new LayeredItemStore(dao, layerManager);
         Files.createDirectories(archiveDir);
         layeredStore.createDirectory("a/b/c/d");
-        layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!"));
-        layeredStore.writeFile("a/b/c/d/test2.txt", toInputStream("Hello world!"));
-        layeredStore.writeFile("a/b/c/test3.txt", toInputStream("Hello again!"));
+        layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!", UTF_8));
+        layeredStore.writeFile("a/b/c/d/test2.txt", toInputStream("Hello world!", UTF_8));
+        layeredStore.writeFile("a/b/c/test3.txt", toInputStream("Hello again!", UTF_8));
         Path destination = testDir.resolve("copy");
 
         layeredStore.copyDirectoryOutOf("a/b/c/d", destination);

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreDeleteDirectoryTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreDeleteDirectoryTest.java
@@ -103,7 +103,7 @@ public class LayeredItemStoreDeleteDirectoryTest extends AbstractLayerDatabaseTe
 
     @Test
     public void should_throw_cannot_not_delete_file_form_closed_layer() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutor());
         var layeredStore = new LayeredItemStore(dao, layerManager);
         layeredStore.createDirectory("a/b/c/d");
         layeredStore.writeFile("a/b/c/test.txt", toInputStream("Hello world!"));
@@ -119,6 +119,7 @@ public class LayeredItemStoreDeleteDirectoryTest extends AbstractLayerDatabaseTe
         // method under test
         assertThatThrownBy(() -> layeredStore.deleteFiles(List.of("a/b/c/test.txt")))
             .isInstanceOf(NoSuchFileException.class); // this is a failure for the wrong reason
+
         assumeNotYetFixed("deleteFiles gets new layer object. New layer objects are open but it should be closed in this scenario.");
         assertThatThrownBy(() -> layeredStore.deleteFiles(List.of("a/b/c/test.txt")))
             .isInstanceOf(IllegalStateException.class)

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreDeleteDirectoryTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreDeleteDirectoryTest.java
@@ -105,7 +105,7 @@ public class LayeredItemStoreDeleteDirectoryTest extends AbstractLayerDatabaseTe
     }
 
     @Test
-    public void should_throw_cannot_not_delete_file_form_closed_layer() throws Exception {
+    public void should_throw_cannot_delete_file_from_closed_layer() throws Exception {
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutor());
         var layeredStore = new LayeredItemStore(dao, layerManager);
         layeredStore.createDirectory("a/b/c/d");

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreDeleteDirectoryTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreDeleteDirectoryTest.java
@@ -23,8 +23,9 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.List;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static nl.knaw.dans.layerstore.TestUtils.assumeNotYetFixed;
-import static nl.knaw.dans.layerstore.TestUtils.toInputStream;
+import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
@@ -79,7 +80,7 @@ public class LayeredItemStoreDeleteDirectoryTest extends AbstractLayerDatabaseTe
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
         var layeredStore = new LayeredItemStore(dao, layerManager);
         layeredStore.createDirectory("a/b/c/d");
-        layeredStore.writeFile("a/b/c/test.txt", toInputStream("Hello world!"));
+        layeredStore.writeFile("a/b/c/test.txt", toInputStream("Hello world!", UTF_8));
 
         // precondition: show database content
         var list1 = daoTestExtension.inTransaction(() ->
@@ -108,7 +109,7 @@ public class LayeredItemStoreDeleteDirectoryTest extends AbstractLayerDatabaseTe
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutor());
         var layeredStore = new LayeredItemStore(dao, layerManager);
         layeredStore.createDirectory("a/b/c/d");
-        layeredStore.writeFile("a/b/c/test.txt", toInputStream("Hello world!"));
+        layeredStore.writeFile("a/b/c/test.txt", toInputStream("Hello world!", UTF_8));
         Files.createDirectories(archiveDir);
         layerManager.newTopLayer();
 

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreDeleteDirectoryTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreDeleteDirectoryTest.java
@@ -23,6 +23,8 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.List;
 
+import static nl.knaw.dans.layerstore.TestUtils.assumeNotYetFixed;
+import static nl.knaw.dans.layerstore.TestUtils.toInputStream;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreDeleteDirectoryTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreDeleteDirectoryTest.java
@@ -19,7 +19,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
@@ -71,7 +73,7 @@ public class LayeredItemStoreDeleteDirectoryTest extends AbstractLayerDatabaseTe
     }
 
     @Test
-    public void should_delete_directory_with_plain_file() throws Exception {
+    public void should_delete_directory_with_regular_file() throws Exception {
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
         var layeredStore = new LayeredItemStore(dao, layerManager);
         layeredStore.createDirectory("a/b/c/d");
@@ -97,5 +99,29 @@ public class LayeredItemStoreDeleteDirectoryTest extends AbstractLayerDatabaseTe
             dao.getAllRecords().toList().stream().map(ItemRecord::getPath)
         );
         assertThat(list2).containsExactlyInAnyOrder("", "a");
+    }
+
+    @Test
+    public void should_throw_cannot_not_delete_file_form_closed_layer() throws Exception {
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layeredStore = new LayeredItemStore(dao, layerManager);
+        layeredStore.createDirectory("a/b/c/d");
+        layeredStore.writeFile("a/b/c/test.txt", toInputStream("Hello world!"));
+        Files.createDirectories(archiveDir);
+        layerManager.newTopLayer();
+
+        // precondition: show database content
+        var list1 = daoTestExtension.inTransaction(() ->
+            dao.getAllRecords().toList().stream().map(ItemRecord::getPath)
+        );
+        assertThat(list1).containsExactlyInAnyOrder("", "a", "a/b", "a/b/c", "a/b/c/d", "a/b/c/test.txt");
+
+        // method under test
+        assertThatThrownBy(() -> layeredStore.deleteFiles(List.of("a/b/c/test.txt")))
+            .isInstanceOf(NoSuchFileException.class); // this is a failure for the wrong reason
+        assumeNotYetFixed("deleteFiles gets new layer object. New layer objects are open but it should be closed in this scenario.");
+        assertThatThrownBy(() -> layeredStore.deleteFiles(List.of("a/b/c/test.txt")))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageStartingWith("Cannot delete files from closed layer");
     }
 }

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreDeleteFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreDeleteFileTest.java
@@ -22,8 +22,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static nl.knaw.dans.layerstore.TestUtils.assumeNotYetFixed;
-import static nl.knaw.dans.layerstore.TestUtils.toInputStream;
+import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -41,8 +42,8 @@ public class LayeredItemStoreDeleteFileTest extends AbstractLayerDatabaseTest {
         var layeredStore = new LayeredItemStore(dao, layerManager);
         Files.createDirectories(archiveDir);
         layeredStore.createDirectory("a/b/c/d");
-        layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!"));
-        layeredStore.writeFile("a/b/c/test2.txt", toInputStream("Hello again!"));
+        layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!", UTF_8));
+        layeredStore.writeFile("a/b/c/test2.txt", toInputStream("Hello again!", UTF_8));
         var firstLayer = layerManager.getTopLayer();
         layerManager.newTopLayer();
         assertFalse(firstLayer.isOpen());
@@ -58,8 +59,8 @@ public class LayeredItemStoreDeleteFileTest extends AbstractLayerDatabaseTest {
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
         var layeredStore = new LayeredItemStore(dao, layerManager);
         layeredStore.createDirectory("a/b/c/d");
-        layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!"));
-        layeredStore.writeFile("a/b/c/test2.txt", toInputStream("Hello world!"));
+        layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!", UTF_8));
+        layeredStore.writeFile("a/b/c/test2.txt", toInputStream("Hello world!", UTF_8));
 
         // precondition: show database content
         var list1 = daoTestExtension.inTransaction(() ->

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreDeleteFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreDeleteFileTest.java
@@ -45,7 +45,7 @@ public class LayeredItemStoreDeleteFileTest extends AbstractLayerDatabaseTest {
         layerManager.newTopLayer();
         assertFalse(firstLayer.isOpen());
 
-        assumeNotYetFixed("TODO: getLayer returns a new layer object. New layer objects are open but it should be closed in this scenario.");
+        assumeNotYetFixed("getLayer returns a new layer object. New layer objects are open but it should be closed in this scenario.");
         assertThatThrownBy(() -> layeredStore.deleteFiles(List.of("a/b/c/d/test1.txt", "a/b/c/test2.txt")))
             .isInstanceOf(IllegalStateException.class)
             .hasMessageContaining("Cannot delete files from closed layer");

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreDeleteFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreDeleteFileTest.java
@@ -22,6 +22,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
+import static nl.knaw.dans.layerstore.TestUtils.assumeNotYetFixed;
+import static nl.knaw.dans.layerstore.TestUtils.toInputStream;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreExistsPathLikeTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreExistsPathLikeTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
 
+import static nl.knaw.dans.layerstore.TestUtils.toInputStream;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LayeredItemStoreExistsPathLikeTest extends AbstractLayerDatabaseTest {

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreExistsPathLikeTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreExistsPathLikeTest.java
@@ -20,7 +20,8 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
 
-import static nl.knaw.dans.layerstore.TestUtils.toInputStream;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LayeredItemStoreExistsPathLikeTest extends AbstractLayerDatabaseTest {
@@ -36,8 +37,8 @@ public class LayeredItemStoreExistsPathLikeTest extends AbstractLayerDatabaseTes
         var layeredStore = new LayeredItemStore(dao, layerManager);
         Files.createDirectories(archiveDir);
         layeredStore.createDirectory("a/b/c/d/e/f");
-        layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!"));
-        layeredStore.writeFile("a/b/c/test2.txt", toInputStream("Hello again!"));
+        layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!", UTF_8));
+        layeredStore.writeFile("a/b/c/test2.txt", toInputStream("Hello again!", UTF_8));
 
         assertTrue(layeredStore.existsPathLike("%/test%.txt"));
         // More by LayerDatabaseExistsPathLikeTest

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreListDirectoryTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreListDirectoryTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
 
+import static nl.knaw.dans.layerstore.TestUtils.toInputStream;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 public class LayeredItemStoreListDirectoryTest extends AbstractLayerDatabaseTest {

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreListDirectoryTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreListDirectoryTest.java
@@ -20,7 +20,8 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
 
-import static nl.knaw.dans.layerstore.TestUtils.toInputStream;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 public class LayeredItemStoreListDirectoryTest extends AbstractLayerDatabaseTest {
@@ -36,8 +37,8 @@ public class LayeredItemStoreListDirectoryTest extends AbstractLayerDatabaseTest
         var layeredStore = new LayeredItemStore(dao, layerManager);
         Files.createDirectories(archiveDir);
         layeredStore.createDirectory("a/b/c/d/e/f");
-        layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!"));
-        layeredStore.writeFile("a/b/c/test2.txt", toInputStream("Hello again!"));
+        layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!", UTF_8));
+        layeredStore.writeFile("a/b/c/test2.txt", toInputStream("Hello again!", UTF_8));
 
         var result = layeredStore.listDirectory("a/b/c").stream().map(Item::getPath);
 

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreMoveDirectoryInternalTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreMoveDirectoryInternalTest.java
@@ -20,7 +20,8 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
 
-import static nl.knaw.dans.layerstore.TestUtils.toInputStream;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
@@ -38,7 +39,7 @@ public class LayeredItemStoreMoveDirectoryInternalTest extends AbstractLayerData
 
         layeredStore.createDirectory("a/b/c/d");
         layeredStore.createDirectory("a/b/e/f");
-        layeredStore.writeFile("a/b/e/f/test.txt", toInputStream("Hello world!"));
+        layeredStore.writeFile("a/b/e/f/test.txt", toInputStream("Hello world!", UTF_8));
 
         layeredStore.moveDirectoryInternal("a/b/e/f", "a/b/c/d/x");
 
@@ -54,7 +55,7 @@ public class LayeredItemStoreMoveDirectoryInternalTest extends AbstractLayerData
 
         layeredStore.createDirectory("a/b/c/d");
         layeredStore.createDirectory("a/b/e/f");
-        layeredStore.writeFile("a/b/e/f/test.txt", toInputStream("Hello world!"));
+        layeredStore.writeFile("a/b/e/f/test.txt", toInputStream("Hello world!", UTF_8));
         layerManager.newTopLayer();
 
         // without this, a stack trace is logged from an archiving thread

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreMoveDirectoryInternalTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreMoveDirectoryInternalTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
 
+import static nl.knaw.dans.layerstore.TestUtils.toInputStream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreReadFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreReadFileTest.java
@@ -22,7 +22,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 
-import static nl.knaw.dans.layerstore.TestUtils.toInputStream;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
@@ -45,7 +46,7 @@ public class LayeredItemStoreReadFileTest extends AbstractLayerDatabaseTest {
         var layeredStore = new LayeredItemStore(dao, layerManager);
 
         var testContent = "Hello world!";
-        layeredStore.writeFile("test.txt", toInputStream(testContent));
+        layeredStore.writeFile("test.txt", toInputStream(testContent, UTF_8));
 
         try (var inputStream = layeredStore.readFile("test.txt")) {
             assertThat(inputStream).hasContent(testContent);
@@ -58,7 +59,7 @@ public class LayeredItemStoreReadFileTest extends AbstractLayerDatabaseTest {
         var layeredStore = new LayeredItemStore(dao, layerManager, new StoreTxtContent());
 
         var testContent = "Hello world!";
-        layeredStore.writeFile("test.txt", toInputStream(testContent));
+        layeredStore.writeFile("test.txt", toInputStream(testContent, UTF_8));
 
         try (var inputStream = layeredStore.readFile("test.txt")) {
             assertThat(inputStream).hasContent(testContent);

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreReadFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreReadFileTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 
+import static nl.knaw.dans.layerstore.TestUtils.toInputStream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreWriteFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreWriteFileTest.java
@@ -20,6 +20,8 @@ import org.junit.jupiter.api.Test;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
+import static nl.knaw.dans.layerstore.TestUtils.toBytes;
+import static nl.knaw.dans.layerstore.TestUtils.toInputStream;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class LayeredItemStoreWriteFileTest extends AbstractLayerDatabaseTest {

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreWriteFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreWriteFileTest.java
@@ -21,7 +21,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static nl.knaw.dans.layerstore.TestUtils.toBytes;
 import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -61,7 +60,7 @@ public class LayeredItemStoreWriteFileTest extends AbstractLayerDatabaseTest {
         // Check that the file content is in the database
         dao.getAllRecords().toList().forEach(itemRecord -> {
             if (itemRecord.getPath().equals("test.txt")) {
-                assertThat(itemRecord.getContent()).isEqualTo(toBytes(testContent));
+                assertThat(itemRecord.getContent()).isEqualTo(testContent.getBytes(UTF_8));
             }
         });
     }
@@ -78,7 +77,7 @@ public class LayeredItemStoreWriteFileTest extends AbstractLayerDatabaseTest {
         // Check that the file content is in the database
         dao.getAllRecords().toList().forEach(itemRecord -> {
             if (itemRecord.getPath().equals("test.txt")) {
-                assertThat(itemRecord.getContent()).isEqualTo(toBytes("Hello again!"));
+                assertThat(itemRecord.getContent()).isEqualTo("Hello again!".getBytes(UTF_8));
             }
         });
 

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreWriteFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreWriteFileTest.java
@@ -20,8 +20,9 @@ import org.junit.jupiter.api.Test;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static nl.knaw.dans.layerstore.TestUtils.toBytes;
-import static nl.knaw.dans.layerstore.TestUtils.toInputStream;
+import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class LayeredItemStoreWriteFileTest extends AbstractLayerDatabaseTest {
@@ -39,7 +40,7 @@ public class LayeredItemStoreWriteFileTest extends AbstractLayerDatabaseTest {
         var layeredStore = new LayeredItemStore(dao, layerManager);
 
         var testContent = "Hello world!";
-        layeredStore.writeFile("test.txt", toInputStream(testContent));
+        layeredStore.writeFile("test.txt", toInputStream(testContent, UTF_8));
 
         var topLayer = layerManager.getTopLayer();
 
@@ -55,7 +56,7 @@ public class LayeredItemStoreWriteFileTest extends AbstractLayerDatabaseTest {
         var layeredStore = new LayeredItemStore(dao, layerManager, new StoreTxtContent());
 
         var testContent = "Hello world!";
-        layeredStore.writeFile("test.txt", toInputStream(testContent));
+        layeredStore.writeFile("test.txt", toInputStream(testContent, UTF_8));
 
         // Check that the file content is in the database
         dao.getAllRecords().toList().forEach(itemRecord -> {
@@ -71,8 +72,8 @@ public class LayeredItemStoreWriteFileTest extends AbstractLayerDatabaseTest {
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
         var layeredStore = new LayeredItemStore(dao, layerManager, new StoreTxtContent());
 
-        layeredStore.writeFile("test.txt", toInputStream("Hello world!"));
-        layeredStore.writeFile("test.txt", toInputStream("Hello again!"));
+        layeredStore.writeFile("test.txt", toInputStream("Hello world!", UTF_8));
+        layeredStore.writeFile("test.txt", toInputStream("Hello again!", UTF_8));
 
         // Check that the file content is in the database
         dao.getAllRecords().toList().forEach(itemRecord -> {
@@ -90,11 +91,11 @@ public class LayeredItemStoreWriteFileTest extends AbstractLayerDatabaseTest {
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
         var layeredStore = new LayeredItemStore(dao, layerManager, new StoreTxtContent());
 
-        layeredStore.writeFile("test.txt", toInputStream("Hello world!"));
+        layeredStore.writeFile("test.txt", toInputStream("Hello world!", UTF_8));
         layerManager.newTopLayer();
-        layeredStore.writeFile("test.txt", toInputStream("Hello again!"));
+        layeredStore.writeFile("test.txt", toInputStream("Hello again!", UTF_8));
         layerManager.newTopLayer();
-        layeredStore.writeFile("test.txt", toInputStream("Hello once more!"));
+        layeredStore.writeFile("test.txt", toInputStream("Hello once more!", UTF_8));
 
         // Check that the file contents are in the database
         var list = dao.getAllRecords().map(itemRecord ->

--- a/src/test/java/nl/knaw/dans/layerstore/ProcessRunnerTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ProcessRunnerTest.java
@@ -22,8 +22,8 @@ import org.junit.jupiter.api.condition.OS;
 import java.nio.file.Files;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ProcessRunnerTest extends AbstractTestWithTestDir {
 
@@ -45,6 +45,8 @@ public class ProcessRunnerTest extends AbstractTestWithTestDir {
 
     @Test // Whether the `ls` command is available is irrelevant here
     public void run_should_throw_an_exception_when_the_command_or_arguments_contain_forbidden_characters() throws Exception {
-        assertThrows(IllegalArgumentException.class, () -> new ProcessRunner("ls", ";", "echo", "evil", ">", "/tmp/somefile.txt").runToEnd());
+        assertThatThrownBy(() -> new ProcessRunner("ls", ";", "echo", "evil", ">", "/tmp/somefile.txt"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Command or arguments contain forbidden characters: ;, >");
     }
 }

--- a/src/test/java/nl/knaw/dans/layerstore/ProcessRunnerTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ProcessRunnerTest.java
@@ -44,7 +44,7 @@ public class ProcessRunnerTest extends AbstractTestWithTestDir {
     }
 
     @Test // Whether the `ls` command is available is irrelevant here
-    public void run_should_throw_an_exception_when_the_command_or_arguments_contain_forbidden_characters() throws Exception {
+    public void run_should_throw_an_exception_when_the_command_or_arguments_contain_forbidden_characters() {
         assertThatThrownBy(() -> new ProcessRunner("ls", ";", "echo", "evil", ">", "/tmp/somefile.txt"))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("Command or arguments contain forbidden characters: ;, >");

--- a/src/test/java/nl/knaw/dans/layerstore/TestUtils.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TestUtils.java
@@ -24,8 +24,6 @@ import org.slf4j.LoggerFactory;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class TestUtils {
@@ -42,10 +40,6 @@ public class TestUtils {
         var outContent = new ByteArrayOutputStream();
         System.setOut(new PrintStream(outContent));
         return outContent;
-    }
-
-    public static byte[] toBytes(String testContent) {
-        return testContent.getBytes(UTF_8);
     }
 
     /**

--- a/src/test/java/nl/knaw/dans/layerstore/TestUtils.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TestUtils.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.layerstore;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class TestUtils {
+    public static ListAppender<ILoggingEvent> captureLog() {
+        var logger = (Logger) LoggerFactory.getLogger(LayerManagerImpl.class);
+        ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+        listAppender.start();
+        logger.setLevel(Level.ERROR);
+        logger.addAppender(listAppender);
+        return listAppender;
+    }
+
+    public static ByteArrayOutputStream captureStdout() {
+        var outContent = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outContent));
+        return outContent;
+    }
+
+    public static ByteArrayInputStream toInputStream(String testContent) {
+        return new ByteArrayInputStream(toBytes(testContent));
+    }
+
+    public static byte[] toBytes(String testContent) {
+        return testContent.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Assume that a bug is not yet fixed. This allows to skip assertions while still showing the code is covered by the test.
+     *
+     * @param message the message to display
+     */
+    public static void assumeNotYetFixed(String message) {
+        assumeTrue(false, message);
+    }
+}

--- a/src/test/java/nl/knaw/dans/layerstore/TestUtils.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TestUtils.java
@@ -21,11 +21,11 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class TestUtils {
@@ -44,12 +44,8 @@ public class TestUtils {
         return outContent;
     }
 
-    public static ByteArrayInputStream toInputStream(String testContent) {
-        return new ByteArrayInputStream(toBytes(testContent));
-    }
-
     public static byte[] toBytes(String testContent) {
-        return testContent.getBytes(StandardCharsets.UTF_8);
+        return testContent.getBytes(UTF_8);
     }
 
     /**

--- a/src/test/java/nl/knaw/dans/layerstore/TestUtils.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TestUtils.java
@@ -47,7 +47,8 @@ public class TestUtils {
     }
 
     /**
-     * Assume that a bug is not yet fixed. This allows to skip assertions while still showing the code is covered by the test.
+     * Assume that a bug is not yet fixed. This allows to execute as much of a test as possible
+     * to show code coverage, without creating false positives or false negatives.
      *
      * @param message the message to display
      */

--- a/src/test/java/nl/knaw/dans/layerstore/TestUtils.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TestUtils.java
@@ -19,10 +19,14 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -49,5 +53,14 @@ public class TestUtils {
      */
     public static void assumeNotYetFixed(String message) {
         assumeTrue(false, message);
+    }
+
+    static ZipFile zipFileFrom(Path zipFile) throws IOException {
+        // replaces deprecated constructor
+        return ZipFile.builder()
+            .setSeekableByteChannel(Files.newByteChannel(zipFile))
+            .setUseUnicodeExtraFields(true)
+            .setIgnoreLocalFileHeader(false)
+            .get();
     }
 }

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveArchiveFromTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveArchiveFromTest.java
@@ -15,13 +15,13 @@
  */
 package nl.knaw.dans.layerstore;
 
-import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
 import java.util.Collections;
 
+import static nl.knaw.dans.layerstore.TestUtils.zipFileFrom;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 public class ZipArchiveArchiveFromTest extends AbstractTestWithTestDir {
@@ -48,7 +48,7 @@ public class ZipArchiveArchiveFromTest extends AbstractTestWithTestDir {
 
         // Check that the zip file exists and contains the files and not more than that
         assertThat(zipFile).exists();
-        try (var zf = new ZipFile(zipFile.toFile())) {
+        try (var zf = zipFileFrom(zipFile)) {
             assertThat(zf.getEntry("file1")).isNotNull();
             assertThat(zf.getEntry("path/to/file2")).isNotNull();
             assertThat(zf.getEntry("path/to/file3")).isNotNull();

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveUnarchiveToTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveUnarchiveToTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import static nl.knaw.dans.layerstore.TestUtils.assumeNotYetFixed;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 


### PR DESCRIPTION
Fixes DD-1532: 4th batch of unit test

# Description of changes
* refactoring
  * assertThrows -> assertThrownBy
  * use archiveDir where appropriate
  * renames and extracted values (for readability) in `LayeredItemStore.writeFile`
  * replaced homemade toInputStream by IOUtils version
* cover exceptions in `LayeredItemStore.getItemType` and `LayerManager.newTopLayerTest`
* new techniques:
  * capture stdout (appears because of throwing thread despite capture of logging)
  * DirectExecutor (to avoid thread problems)

# How to test


# Related PRs 
(Add links)
* 

# Notify
@DANS-KNAW/core-systems
