### PR TITLE
DD-1532 5th set of unit tests: ZipArchive and TarArchive

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,11 +88,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/src/main/java/nl/knaw/dans/layerstore/TarArchive.java
+++ b/src/main/java/nl/knaw/dans/layerstore/TarArchive.java
@@ -57,6 +57,7 @@ public class TarArchive implements Archive {
             @Override
             @SneakyThrows
             public void close() {
+                super.close();
                 // Close the backing stream.
                 tar.close();
             }

--- a/src/main/java/nl/knaw/dans/layerstore/TarArchive.java
+++ b/src/main/java/nl/knaw/dans/layerstore/TarArchive.java
@@ -76,7 +76,7 @@ public class TarArchive implements Archive {
             }
             for (TarArchiveEntry entry : entries) {
                 var filePath = stagingDir.resolve(entry.getName());
-                if (filePath.normalize().startsWith(stagingDir)) {
+                if (filePath.normalize().startsWith(stagingDir)) { // keep CodeQL happy
                     if (entry.isDirectory()) {
                         Files.createDirectories(filePath);
                     }

--- a/src/main/java/nl/knaw/dans/layerstore/TarArchive.java
+++ b/src/main/java/nl/knaw/dans/layerstore/TarArchive.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.util.stream.Stream;
 
 import static java.text.MessageFormat.format;
 
@@ -99,10 +100,13 @@ public class TarArchive implements Archive {
     @Override
     @SneakyThrows
     public void archiveFrom(Path stagingDir) {
+        Stream<Path> emptyFileStream = Stream.empty();
         try (var outputStream = Files.newOutputStream(tarFile);
             var bufferedOutputStream = new BufferedOutputStream(outputStream);
             var tarOutput = new TarArchiveOutputStream(bufferedOutputStream);
-            var files = Files.walk(stagingDir)
+            var files = stagingDir.toFile().exists()
+                ? Files.walk(stagingDir)
+                : emptyFileStream // supports LayerManager.newTopLayer() in case of an empty staging directory
         ) {
             tarOutput.setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU);
             for (var fileToArchive : files.toList()) {

--- a/src/main/java/nl/knaw/dans/layerstore/TarArchive.java
+++ b/src/main/java/nl/knaw/dans/layerstore/TarArchive.java
@@ -116,7 +116,6 @@ public class TarArchive implements Archive {
     }
 
     @Override
-    @SneakyThrows
     public boolean fileExists(String filePath) {
         try (var tar = new TarFile(tarFile.toFile())) {
             return tar.getEntries().stream().anyMatch(e ->

--- a/src/main/java/nl/knaw/dans/layerstore/TarArchive.java
+++ b/src/main/java/nl/knaw/dans/layerstore/TarArchive.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.text.MessageFormat;
 
 import static java.text.MessageFormat.format;
 
@@ -66,21 +67,19 @@ public class TarArchive implements Archive {
     @Override
     public void unarchiveTo(Path stagingDir) {
         try (var tar = new TarFile(tarFile.toFile())) {
-            tar.getEntries().forEach(entry -> {
-                try {
-                    if (entry.isDirectory()) {
-                        Files.createDirectories(stagingDir.resolve(entry.getName()));
-                    }
-                    else {
-                        Path file = stagingDir.resolve(entry.getName());
-                        Files.createDirectories(file.getParent());
-                        IOUtils.copy(tar.getInputStream(entry), Files.newOutputStream(file));
-                    }
+            for (TarArchiveEntry entry : tar.getEntries()) {
+                var filePath = stagingDir.resolve(entry.getName());
+                if (!filePath.normalize().startsWith(stagingDir)) {
+                    throw new IOException(format("Detected Zip Slip vulnerability: {0} in {1}", entry.getName(), tarFile));
                 }
-                catch (IOException e) {
-                    throw new RuntimeException("Could not unarchive " + tarFile.toFile(), e);
+                if (entry.isDirectory()) {
+                    Files.createDirectories(filePath);
                 }
-            });
+                else {
+                    Files.createDirectories(filePath.getParent());
+                    IOUtils.copy(tar.getInputStream(entry), Files.newOutputStream(filePath));
+                }
+            }
         }
         catch (IOException e) {
             throw new RuntimeException("Could not unarchive " + tarFile.toFile(), e);

--- a/src/main/java/nl/knaw/dans/layerstore/TarArchive.java
+++ b/src/main/java/nl/knaw/dans/layerstore/TarArchive.java
@@ -21,8 +21,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
-import org.apache.commons.compress.utils.BoundedInputStream;
-import org.apache.commons.compress.utils.IOUtils;
+import org.apache.commons.io.input.BoundedInputStream;
+import org.apache.commons.io.IOUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -47,10 +47,10 @@ public class TarArchive implements Archive {
     @Override
     public InputStream readFile(String filePath) throws IOException {
         // No try-with-resources on tarInput, so that we can use it to back the BoundedInputStream
-        TarArchiveInputStream tarInput = new TarArchiveInputStream(Files.newInputStream(tarFile));
+        var tarInput = new TarArchiveInputStream(Files.newInputStream(tarFile));
         try {
             TarArchiveEntry entry;
-            while ((entry = tarInput.getNextTarEntry()) != null) {
+            while ((entry = tarInput.getNextEntry()) != null) {
                 if (entry.getName().equals(filePath)) {
                     return new BoundedInputStream(tarInput, entry.getSize()) {
 
@@ -77,7 +77,7 @@ public class TarArchive implements Archive {
     public void unarchiveTo(Path stagingDir) {
         try (TarArchiveInputStream tarInput = new TarArchiveInputStream(Files.newInputStream(tarFile))) {
             TarArchiveEntry entry;
-            while ((entry = tarInput.getNextTarEntry()) != null) {
+            while ((entry = tarInput.getNextEntry()) != null) {
                 Path outputPath = stagingDir.resolve(entry.getName());
                 if (entry.isDirectory()) {
                     Files.createDirectories(outputPath);
@@ -128,7 +128,7 @@ public class TarArchive implements Archive {
     public boolean fileExists(String filePath) {
         try (TarArchiveInputStream tarInput = new TarArchiveInputStream(Files.newInputStream(tarFile))) {
             TarArchiveEntry entry;
-            while ((entry = tarInput.getNextTarEntry()) != null) {
+            while ((entry = tarInput.getNextEntry()) != null) {
                 if (entry.getName().equals(filePath)) {
                     return true;
                 }

--- a/src/main/java/nl/knaw/dans/layerstore/TarArchive.java
+++ b/src/main/java/nl/knaw/dans/layerstore/TarArchive.java
@@ -25,10 +25,12 @@ import org.apache.commons.io.IOUtils;
 
 import java.io.BufferedOutputStream;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 
 import static java.text.MessageFormat.format;
@@ -129,13 +131,14 @@ public class TarArchive implements Archive {
     }
 
     @Override
+    @SneakyThrows
     public boolean fileExists(String filePath) {
         try (var tar = new TarFile(tarFile.toFile())) {
             return tar.getEntries().stream().anyMatch(e ->
                 e.getName().equals(filePath)
             );
         }
-        catch (IOException e) {
+        catch (NoSuchFileException | FileNotFoundException e) {
             return false;
         }
     }

--- a/src/main/java/nl/knaw/dans/layerstore/ZipArchive.java
+++ b/src/main/java/nl/knaw/dans/layerstore/ZipArchive.java
@@ -59,6 +59,7 @@ public class ZipArchive implements Archive {
             @Override
             @SneakyThrows
             public void close() {
+                super.close();
                 // Close the backing stream.
                 zip.close();
             }

--- a/src/main/java/nl/knaw/dans/layerstore/ZipArchive.java
+++ b/src/main/java/nl/knaw/dans/layerstore/ZipArchive.java
@@ -55,9 +55,14 @@ public class ZipArchive implements Archive {
             return inputStream.read();
         }
 
+        public boolean exists() throws IOException {
+            return inputStream != null;
+        }
+
         @Override
         public void close() throws IOException {
-            inputStream.close();
+            if (inputStream != null) // no inputStream if the entry did not exist
+                inputStream.close();
             zipFile.close();
         }
     }
@@ -151,8 +156,8 @@ public class ZipArchive implements Archive {
 
     @Override
     public boolean fileExists(String filePath) {
-        try (var is = readFile(filePath)) {
-            return is != null;
+        try (var is = (EntryInputStream) readFile(filePath)) {
+            return is.exists();
         }
         catch (IOException e) {
             return false;

--- a/src/main/java/nl/knaw/dans/layerstore/ZipArchive.java
+++ b/src/main/java/nl/knaw/dans/layerstore/ZipArchive.java
@@ -130,5 +130,4 @@ public class ZipArchive implements Archive {
             return false;
         }
     }
-
 }

--- a/src/main/java/nl/knaw/dans/layerstore/ZipArchive.java
+++ b/src/main/java/nl/knaw/dans/layerstore/ZipArchive.java
@@ -32,6 +32,7 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.stream.Stream;
 
 import static java.text.MessageFormat.format;
 
@@ -98,10 +99,13 @@ public class ZipArchive implements Archive {
     @Override
     @SneakyThrows
     public void archiveFrom(Path stagingDir) {
+        Stream<Path> emptyFileStream = Stream.empty();
         try (var outputStream = Files.newOutputStream(zipFile);
             var bufferedOutputStream = new BufferedOutputStream(outputStream);
             var zipOutput = new ZipArchiveOutputStream(bufferedOutputStream);
-            var files = Files.walk(stagingDir)
+            var files = stagingDir.toFile().exists()
+                ? Files.walk(stagingDir)
+                : emptyFileStream // supports LayerManager.newTopLayer() in case of an empty staging directory
         ) {
             for (var fileToArchive : files.toList()) {
                 if (!fileToArchive.equals(stagingDir)) {

--- a/src/main/java/nl/knaw/dans/layerstore/ZipArchive.java
+++ b/src/main/java/nl/knaw/dans/layerstore/ZipArchive.java
@@ -24,10 +24,12 @@ import org.apache.commons.io.IOUtils;
 
 import java.io.BufferedOutputStream;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.Collections;
 
@@ -127,6 +129,7 @@ public class ZipArchive implements Archive {
     }
 
     @Override
+    @SneakyThrows
     public boolean fileExists(String filePath) {
 
         try (var zip = ZipFile.builder().setFile(this.zipFile.toFile()).get()) {
@@ -134,7 +137,7 @@ public class ZipArchive implements Archive {
                 e.getName().equals(filePath)
             );
         }
-        catch (IOException e) {
+        catch (NoSuchFileException | FileNotFoundException e) {
             return false;
         }
     }

--- a/src/main/java/nl/knaw/dans/layerstore/ZipArchive.java
+++ b/src/main/java/nl/knaw/dans/layerstore/ZipArchive.java
@@ -67,11 +67,15 @@ public class ZipArchive implements Archive {
     @Override
     public void unarchiveTo(Path stagingDir) {
         try (var zip = ZipFile.builder().setFile(this.zipFile.toFile()).get()) {
-            for (ZipArchiveEntry entry : Collections.list(zip.getEntries())) {
+            var entries = Collections.list(zip.getEntries());
+            for (ZipArchiveEntry entry : entries) {
                 var filePath = stagingDir.resolve(entry.getName());
                 if (!filePath.normalize().startsWith(stagingDir)) {
-                    throw new IOException(format("Detected Zip Slip vulnerability: {0} in {1}", entry.getName(), zipFile));
+                    throw new IOException(format("Detected Zip Slip: {0} in {1}", entry.getName(), zipFile));
                 }
+            }
+            for (ZipArchiveEntry entry : entries) {
+                var filePath = stagingDir.resolve(entry.getName());
                 if (entry.isDirectory()) {
                     Files.createDirectories(stagingDir.resolve(filePath));
                 }

--- a/src/test/java/nl/knaw/dans/layerstore/AbstractCapturingTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/AbstractCapturingTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.layerstore;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+
+public abstract class AbstractCapturingTest extends AbstractTestWithTestDir {
+    private final PrintStream originalStdout = System.out;
+    private final PrintStream originalStderr = System.err;
+    protected OutputStream stdout;
+    protected OutputStream stderr;
+    protected ListAppender<ILoggingEvent> logged;
+
+    @AfterEach
+    public void tearDown() {
+
+        System.setOut(originalStdout);
+        System.setErr(originalStderr);
+    }
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        stdout = captureStdout();
+        stderr = captureStderr();
+        logged = captureLog(Level.DEBUG, "nl.knaw.dans");
+    }
+
+    public static ListAppender<ILoggingEvent> captureLog(Level error, String loggerName) {
+        var logger = (Logger) LoggerFactory.getLogger(loggerName);
+        ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+        listAppender.start();
+        logger.setLevel(error);
+        logger.addAppender(listAppender);
+        return listAppender;
+    }
+
+    public static ByteArrayOutputStream captureStdout() {
+        var outContent = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outContent));
+        return outContent;
+    }
+
+    public static ByteArrayOutputStream captureStderr() {
+        var outContent = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(outContent));
+        return outContent;
+    }
+}

--- a/src/test/java/nl/knaw/dans/layerstore/AbstractTestWithTestDir.java
+++ b/src/test/java/nl/knaw/dans/layerstore/AbstractTestWithTestDir.java
@@ -32,10 +32,10 @@ public abstract class AbstractTestWithTestDir {
 
     protected final Path archiveDir = testDir.resolve("layer_archive");
 
-    public void createStagingFileWithContent(String path) throws IOException {
+    public void createStagingFileWithContent(String path, String content) throws IOException {
         var filePath = stagingDir.resolve(path);
         FileUtils.forceMkdir(filePath.getParent().toFile());
-        FileUtils.write(filePath.toFile(), path + " content", "UTF-8");
+        FileUtils.write(filePath.toFile(), content, "UTF-8");
     }
 
     @BeforeEach

--- a/src/test/java/nl/knaw/dans/layerstore/AbstractTestWithTestDir.java
+++ b/src/test/java/nl/knaw/dans/layerstore/AbstractTestWithTestDir.java
@@ -32,6 +32,12 @@ public abstract class AbstractTestWithTestDir {
 
     protected final Path archiveDir = testDir.resolve("layer_archive");
 
+    public void createStagingFileWithContent(String path) throws IOException {
+        var filePath = stagingDir.resolve(path);
+        FileUtils.forceMkdir(filePath.getParent().toFile());
+        FileUtils.write(filePath.toFile(), path + " content", "UTF-8");
+    }
+
     @BeforeEach
     public void setUp() throws Exception {
         if (testDir.toFile().exists()) {

--- a/src/test/java/nl/knaw/dans/layerstore/LayerArchiveTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerArchiveTest.java
@@ -35,6 +35,7 @@ public class LayerArchiveTest extends AbstractTestWithTestDir {
     @Test
     public void throws_IllegalStateException_when_layer_is_already_archived() throws IOException {
         Files.createDirectories(archiveDir);
+        Files.createDirectories(stagingDir);
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         layer.close();
         layer.archive();

--- a/src/test/java/nl/knaw/dans/layerstore/LayerManagerConstructorTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerManagerConstructorTest.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.layerstore;
 
+import io.dropwizard.util.DirectExecutorService;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -28,7 +29,7 @@ public class LayerManagerConstructorTest extends AbstractLayerDatabaseTest {
     @Test
     public void should_create_the_staging_root() throws IOException {
         assertThat(stagingDir).doesNotExist();
-        new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
         assertThat(stagingDir).isEmptyDirectory();
     }
 
@@ -37,7 +38,7 @@ public class LayerManagerConstructorTest extends AbstractLayerDatabaseTest {
         var existingLayerId = 1234567890123L;
         Files.createDirectories(stagingDir.resolve(String.valueOf(existingLayerId)));
 
-        var topLayerId = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir))
+        var topLayerId = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService())
             .getTopLayer().getId();
         assertThat(topLayerId).isEqualTo(existingLayerId);
     }
@@ -48,7 +49,7 @@ public class LayerManagerConstructorTest extends AbstractLayerDatabaseTest {
         var invalidFileBetweenLayerDirs = "1234567890123";
         Files.createFile(stagingDir.resolve(invalidFileBetweenLayerDirs));
 
-        assertThatThrownBy(() -> new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir)))
+        assertThatThrownBy(() -> new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService()))
             .isInstanceOf(IllegalStateException.class)
             .hasMessage("Not a directory: target/test/LayerManagerConstructorTest/layer_staging/" + invalidFileBetweenLayerDirs);
     }
@@ -58,7 +59,7 @@ public class LayerManagerConstructorTest extends AbstractLayerDatabaseTest {
         var existingLayerDir = "123456789012";
         Files.createDirectories(stagingDir.resolve(existingLayerDir));
 
-        assertThatThrownBy(() -> new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir)))
+        assertThatThrownBy(() -> new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService()))
             .isInstanceOf(IllegalStateException.class)
             .hasMessage("Not a timestamp: target/test/LayerManagerConstructorTest/layer_staging/" + existingLayerDir);
     }
@@ -68,7 +69,7 @@ public class LayerManagerConstructorTest extends AbstractLayerDatabaseTest {
         var invalidDirBetweenLayerDirs = "abcdefghijklmnopqrstuvwxyz";
         Files.createDirectories(stagingDir.resolve(invalidDirBetweenLayerDirs));
 
-        assertThatThrownBy(() -> new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir)))
+        assertThatThrownBy(() -> new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService()))
             .isInstanceOf(IllegalStateException.class)
             .hasMessage("Not a timestamp: target/test/LayerManagerConstructorTest/layer_staging/" + invalidDirBetweenLayerDirs);
     }
@@ -78,7 +79,7 @@ public class LayerManagerConstructorTest extends AbstractLayerDatabaseTest {
         var invalidDirBetweenLayerDirs = "1.2";
         Files.createDirectories(stagingDir.resolve(invalidDirBetweenLayerDirs));
 
-        assertThatThrownBy(() -> new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir)))
+        assertThatThrownBy(() -> new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService()))
             .isInstanceOf(IllegalStateException.class)
             .hasMessage("Not a timestamp: target/test/LayerManagerConstructorTest/layer_staging/" + invalidDirBetweenLayerDirs);
     }

--- a/src/test/java/nl/knaw/dans/layerstore/LayerManagerGetLayerTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerManagerGetLayerTest.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.layerstore;
 
+import io.dropwizard.util.DirectExecutorService;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -33,7 +34,7 @@ public class LayerManagerGetLayerTest extends AbstractTestWithTestDir {
     @Test
     public void should_throw_when_layer_id_does_not_exist() throws IOException {
         // Given
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
 
         // When
         assertThatThrownBy(() -> layerManager.getLayer(1234567890123L))
@@ -46,7 +47,7 @@ public class LayerManagerGetLayerTest extends AbstractTestWithTestDir {
     @Test
     public void should_find_garbage_in_stagingDir_created_after_creating_LayerManagerImpl_object() throws IOException {
         // Given
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
         Files.createDirectories(stagingDir.resolve("0"));
 
         //When
@@ -59,7 +60,7 @@ public class LayerManagerGetLayerTest extends AbstractTestWithTestDir {
     @Test
     public void should_find_a_top_layer_with_content() throws IOException {
         // Given
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
         var topLayer = layerManager.getTopLayer();
         topLayer.writeFile("test.txt", toInputStream("Hello world!", UTF_8));
 
@@ -73,7 +74,7 @@ public class LayerManagerGetLayerTest extends AbstractTestWithTestDir {
     @Test
     public void should_find_an_empty_top_layer() throws IOException {
         // Given
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
         long topLayerId = layerManager.getTopLayer().getId();
         assertThat(stagingDir.resolve(String.valueOf(topLayerId))).doesNotExist();
 
@@ -111,7 +112,7 @@ public class LayerManagerGetLayerTest extends AbstractTestWithTestDir {
     public void should_have_status_archived_for_the_found_layer() throws Exception {
         // Given
         Files.createDirectories(archiveDir);
-        var layerManager = new LayerManagerImpl(stagingDir, new TarArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new TarArchiveProvider(archiveDir), new DirectExecutorService());
         layerManager.getTopLayer().writeFile("test.txt", toInputStream("Hello world!", UTF_8));
         Layer initialLayer = layerManager.getTopLayer();
         var initialLayerId = initialLayer.getId();

--- a/src/test/java/nl/knaw/dans/layerstore/LayerManagerGetLayerTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerManagerGetLayerTest.java
@@ -111,7 +111,7 @@ public class LayerManagerGetLayerTest extends AbstractTestWithTestDir {
     public void should_have_status_archived_for_the_found_layer() throws Exception {
         // Given
         Files.createDirectories(archiveDir);
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new TarArchiveProvider(archiveDir));
         layerManager.getTopLayer().writeFile("test.txt", toInputStream("Hello world!", UTF_8));
         Layer initialLayer = layerManager.getTopLayer();
         var initialLayerId = initialLayer.getId();
@@ -125,7 +125,7 @@ public class LayerManagerGetLayerTest extends AbstractTestWithTestDir {
         // Then
         assertThat(initialLayerId).isEqualTo(layer.getId());
         assertThat(archiveDir).isNotEmptyDirectory();
-        assertThat(archiveDir.resolve(initialLayerId + ".zip")).exists();
+        assertThat(archiveDir.resolve(initialLayerId + ".tar")).exists();
         assumeNotYetFixed("The layer is archived, but neither the object of the initial top layer, nor the new layer object know it.");
         assertFalse(initialLayer.isArchived());
         assertFalse(layer.isArchived());

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreCopyDirectoryOutOfTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreCopyDirectoryOutOfTest.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.layerstore;
 
+import io.dropwizard.util.DirectExecutorService;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,7 +37,7 @@ public class LayeredItemStoreCopyDirectoryOutOfTest extends AbstractLayerDatabas
 
     @Test
     public void should_copy_an_empty_child_directory() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
         var layeredStore = new LayeredItemStore(db, layerManager);
         Files.createDirectories(archiveDir);
         layeredStore.createDirectory("a/b/c/d/e");
@@ -52,7 +53,7 @@ public class LayeredItemStoreCopyDirectoryOutOfTest extends AbstractLayerDatabas
     @Test
     public void should_overwrite_existing_files() throws Exception {
         // As in https://github.com/OCFL/ocfl-java/blob/a4d4f17149640132bdfd9c00a170f414e1c7cf33/ocfl-java-core/src/main/java/io/ocfl/core/storage/filesystem/FileSystemStorage.java#L226C1-L243C6
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
         var layeredStore = new LayeredItemStore(db, layerManager);
         Files.createDirectories(archiveDir);
         layeredStore.createDirectory("a/b/c/d/e");
@@ -68,7 +69,7 @@ public class LayeredItemStoreCopyDirectoryOutOfTest extends AbstractLayerDatabas
 
     @Test
     public void should_not_copy_an_empty_source_directory() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
         var layeredStore = new LayeredItemStore(db, layerManager);
         Files.createDirectories(archiveDir);
         layeredStore.createDirectory("a/b/c/d/e");
@@ -83,7 +84,7 @@ public class LayeredItemStoreCopyDirectoryOutOfTest extends AbstractLayerDatabas
 
     @Test
     public void should_copy_the_files_of_a_source_which_has_no_child_directories() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
         var layeredStore = new LayeredItemStore(db, layerManager);
         Files.createDirectories(archiveDir);
         layeredStore.createDirectory("a/b/c/d");

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreDeleteDirectoryTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreDeleteDirectoryTest.java
@@ -39,7 +39,7 @@ public class LayeredItemStoreDeleteDirectoryTest extends AbstractLayerDatabaseTe
 
     @Test
     public void should_not_delete_a_directory_with_content_in_another_layer() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
         var layeredStore = new LayeredItemStore(db, layerManager);
         Files.createDirectories(archiveDir);
         layeredStore.createDirectory("a/b/c/d");
@@ -52,7 +52,7 @@ public class LayeredItemStoreDeleteDirectoryTest extends AbstractLayerDatabaseTe
 
     @Test
     public void should_delete_empty_directory() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
         var layeredStore = new LayeredItemStore(db, layerManager);
         layeredStore.createDirectory("a/b/c/d");
 
@@ -78,7 +78,7 @@ public class LayeredItemStoreDeleteDirectoryTest extends AbstractLayerDatabaseTe
 
     @Test
     public void should_delete_directory_with_regular_file() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
         var layeredStore = new LayeredItemStore(db, layerManager);
         layeredStore.createDirectory("a/b/c/d");
         layeredStore.writeFile("a/b/c/test.txt", toInputStream("Hello world!", UTF_8));

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreDeleteFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreDeleteFileTest.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.layerstore;
 
+import io.dropwizard.util.DirectExecutorService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -38,7 +39,7 @@ public class LayeredItemStoreDeleteFileTest extends AbstractLayerDatabaseTest {
 
     @Test
     public void should_not_delete_a_file_in_a_closed_layer() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
         var layeredStore = new LayeredItemStore(db, layerManager);
         Files.createDirectories(archiveDir);
         layeredStore.createDirectory("a/b/c/d");
@@ -56,7 +57,7 @@ public class LayeredItemStoreDeleteFileTest extends AbstractLayerDatabaseTest {
 
     @Test
     public void should_delete_files_from_the_top_layer() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
         var layeredStore = new LayeredItemStore(db, layerManager);
         layeredStore.createDirectory("a/b/c/d");
         layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!", UTF_8));

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreExistsPathLikeTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreExistsPathLikeTest.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.layerstore;
 
+import io.dropwizard.util.DirectExecutorService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +34,7 @@ public class LayeredItemStoreExistsPathLikeTest extends AbstractLayerDatabaseTes
 
     @Test
     public void should_return_a_shallow_list() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
         var layeredStore = new LayeredItemStore(db, layerManager);
         Files.createDirectories(archiveDir);
         layeredStore.createDirectory("a/b/c/d/e/f");

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreListDirectoryTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreListDirectoryTest.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.layerstore;
 
+import io.dropwizard.util.DirectExecutorService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +34,7 @@ public class LayeredItemStoreListDirectoryTest extends AbstractLayerDatabaseTest
 
     @Test
     public void should_return_a_shallow_list() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
         var layeredStore = new LayeredItemStore(db, layerManager);
         Files.createDirectories(archiveDir);
         layeredStore.createDirectory("a/b/c/d/e/f");

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreMoveDirectoryInternalTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreMoveDirectoryInternalTest.java
@@ -35,7 +35,7 @@ public class LayeredItemStoreMoveDirectoryInternalTest extends AbstractLayerData
 
     @Test
     public void should_move_dir_with_file() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
         var layeredStore = new LayeredItemStore(db, layerManager);
 
         layeredStore.createDirectory("a/b/c/d");

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreMoveDirectoryIntoTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreMoveDirectoryIntoTest.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.layerstore;
 
+import io.dropwizard.util.DirectExecutorService;
 import org.apache.commons.io.FileUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,7 +44,7 @@ public class LayeredItemStoreMoveDirectoryIntoTest extends AbstractLayerDatabase
     @Test
     public void should_refuse_to_move_link() throws Exception {
         Files.createSymbolicLink(testDir.resolve("x/y/link"), testDir.resolve("x/test2.txt"));
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
         var layeredStore = new LayeredItemStore(db, layerManager, new StoreTxtContent());
         layeredStore.createDirectory("a/b");
 
@@ -54,7 +55,7 @@ public class LayeredItemStoreMoveDirectoryIntoTest extends AbstractLayerDatabase
 
     @Test
     public void should_add_directory_structure_and_files() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
         var layeredStore = new LayeredItemStore(db, layerManager, new StoreTxtContent());
         layeredStore.createDirectory("a/b");
 
@@ -79,7 +80,7 @@ public class LayeredItemStoreMoveDirectoryIntoTest extends AbstractLayerDatabase
 
     @Test
     public void should_create_parent_in_top_layer() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
         var layeredStore = new LayeredItemStore(db, layerManager);
         layeredStore.createDirectory("a/b");
         Files.createDirectories(archiveDir);
@@ -94,7 +95,7 @@ public class LayeredItemStoreMoveDirectoryIntoTest extends AbstractLayerDatabase
 
     @Test
     public void should_throw_parent_of_destination_does_not_exists() throws IOException {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
         var layeredStore = new LayeredItemStore(db, layerManager);
 
         assertThatThrownBy(() -> layeredStore.moveDirectoryInto(testDir.resolve("x"), "a/b/c")).
@@ -104,7 +105,7 @@ public class LayeredItemStoreMoveDirectoryIntoTest extends AbstractLayerDatabase
 
     @Test
     public void should_throw_destination_exists() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
         var layeredStore = new LayeredItemStore(db, layerManager);
 
         layeredStore.createDirectory("a/b/c");

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreReadFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreReadFileTest.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.layerstore;
 
+import io.dropwizard.util.DirectExecutorService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -42,7 +43,7 @@ public class LayeredItemStoreReadFileTest extends AbstractLayerDatabaseTest {
 
     @Test
     public void should_read_content_from_stagingDir() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
         var layeredStore = new LayeredItemStore(db, layerManager);
 
         var testContent = "Hello world!";
@@ -55,7 +56,7 @@ public class LayeredItemStoreReadFileTest extends AbstractLayerDatabaseTest {
 
     @Test
     public void should_read_content_from_database_if_filter_applies() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
         var layeredStore = new LayeredItemStore(db, layerManager, new StoreTxtContent());
 
         var testContent = "Hello world!";
@@ -68,7 +69,7 @@ public class LayeredItemStoreReadFileTest extends AbstractLayerDatabaseTest {
 
     @Test
     public void should_throw_is_a_directory() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
         var layeredStore = new LayeredItemStore(db, layerManager, new StoreTxtContent());
         layeredStore.createDirectory("a/b/c");
 
@@ -79,7 +80,7 @@ public class LayeredItemStoreReadFileTest extends AbstractLayerDatabaseTest {
 
     @Test
     public void should_throw_no_such_file() throws IOException {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
         var layeredStore = new LayeredItemStore(db, layerManager, new StoreTxtContent());
 
         assertThatThrownBy(() -> layeredStore.readFile("some.txt")).

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreWriteFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreWriteFileTest.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.layerstore;
 
+import io.dropwizard.util.DirectExecutorService;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
@@ -35,7 +36,7 @@ public class LayeredItemStoreWriteFileTest extends AbstractLayerDatabaseTest {
     @Test
     public void should_write_file_to_staging_dir_when_layer_is_open() throws Exception {
         Files.createDirectories(stagingDir);
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
         var layeredStore = new LayeredItemStore(db, layerManager);
 
         var testContent = "Hello world!";
@@ -51,7 +52,7 @@ public class LayeredItemStoreWriteFileTest extends AbstractLayerDatabaseTest {
     @Test
     public void should_write_copy_of_content_to_database_if_filter_applies() throws Exception {
         Files.createDirectories(stagingDir);
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
         var layeredStore = new LayeredItemStore(db, layerManager, new StoreTxtContent());
 
         var testContent = "Hello world!";
@@ -68,7 +69,7 @@ public class LayeredItemStoreWriteFileTest extends AbstractLayerDatabaseTest {
     @Test
     public void should_overwrite_content_in_the_database_if_filter_applies() throws Exception {
         Files.createDirectories(stagingDir);
-        var layerManager = new LayerManagerImpl(stagingDir, new TarArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new TarArchiveProvider(archiveDir), new DirectExecutorService());
         var layeredStore = new LayeredItemStore(db, layerManager, new StoreTxtContent());
 
         layeredStore.writeFile("test.txt", toInputStream("Hello world!", UTF_8));
@@ -87,7 +88,7 @@ public class LayeredItemStoreWriteFileTest extends AbstractLayerDatabaseTest {
     public void should_add_copies_to_the_database_if_filter_applies() throws Exception {
         Files.createDirectories(stagingDir);
         Files.createDirectories(archiveDir);
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
         var layeredStore = new LayeredItemStore(db, layerManager, new StoreTxtContent());
 
         layeredStore.writeFile("test.txt", toInputStream("Hello world!", UTF_8));

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreWriteFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreWriteFileTest.java
@@ -68,7 +68,7 @@ public class LayeredItemStoreWriteFileTest extends AbstractLayerDatabaseTest {
     @Test
     public void should_overwrite_content_in_the_database_if_filter_applies() throws Exception {
         Files.createDirectories(stagingDir);
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new TarArchiveProvider(archiveDir));
         var layeredStore = new LayeredItemStore(db, layerManager, new StoreTxtContent());
 
         layeredStore.writeFile("test.txt", toInputStream("Hello world!", UTF_8));

--- a/src/test/java/nl/knaw/dans/layerstore/TarArchiveArchiveFromTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TarArchiveArchiveFromTest.java
@@ -15,55 +15,48 @@
  */
 package nl.knaw.dans.layerstore;
 
+import lombok.SneakyThrows;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
-import org.apache.commons.io.FileUtils;
+import org.apache.commons.compress.archivers.tar.TarFile;
 import org.junit.jupiter.api.Test;
 
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.util.HashMap;
 import java.util.Map;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Map.entry;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 public class TarArchiveArchiveFromTest extends AbstractTestWithTestDir {
 
     @Test
-    public void should_create_archivefile_and_change_status_to_archived() throws Exception {
-        var tarFile = testDir.resolve("test.tar");
-        var tarArchive = new TarArchive(tarFile);
+    public void should_create_tarfile_and_change_status_to_archived() throws Exception {
+        var archiveFile = testDir.resolve("test.tar");
+        var archive = new TarArchive(archiveFile);
 
-        // Create some files to archive
-        var file1 = stagingDir.resolve("file1");
-        var file2 = stagingDir.resolve("path/to/file2");
-        var file3 = stagingDir.resolve("path/to/file3");
-
-        // Write some string content to the files
-        var file1Content = "file1 content";
-        var file2Content = "file2 content";
-        var file3Content = "file3 content";
-        FileUtils.forceMkdir(file2.getParent().toFile());
-        FileUtils.write(file1.toFile(), file1Content, "UTF-8");
-        FileUtils.write(file2.toFile(), file2Content, "UTF-8");
-        FileUtils.write(file3.toFile(), file3Content, "UTF-8");
+        createStagingFileWithContent("file1");
+        createStagingFileWithContent("path/to/file2");
+        createStagingFileWithContent("path/to/file3");
 
         // Archive the files
-        tarArchive.archiveFrom(stagingDir);
+        archive.archiveFrom(stagingDir);
 
         // Check that the tar file exists and contains the files and not more than that
-        assertThat(tarFile).exists();
-        Map<String, String> actual = new HashMap<>();
-        try (var tf = new TarArchiveInputStream(Files.newInputStream(tarFile))) {
-            TarArchiveEntry entry;
-            while ((entry = tf.getNextEntry()) != null) {
-                actual.put(entry.getName(), new String(tf.readNBytes((int) entry.getSize()), StandardCharsets.UTF_8));
-            }
+        assertThat(archiveFile).exists();
+        try (var tar = new TarFile(archiveFile.toFile())) {
+            assertThat(tar.getEntries().stream().map(tarArchiveEntry ->
+                getEntry(tarArchiveEntry, tar)
+            )).containsExactlyInAnyOrder(
+                entry("file1", "file1 content"),
+                entry("path/to/file2", "path/to/file2 content"),
+                entry("path/to/file3", "path/to/file3 content")
+            );
         }
-        assertThat(actual).containsEntry("file1", file1Content);
-        assertThat(actual).containsEntry("path/to/file2", file2Content);
-        assertThat(actual).containsEntry("path/to/file3", file3Content);
-        assertThat(actual).hasSize(3);
-        assertThat(tarArchive.isArchived()).isTrue();
+    }
+
+    @SneakyThrows
+    private static Map.Entry<String, String> getEntry(TarArchiveEntry tarArchiveEntry, TarFile tar) {
+        var bytes = tar.getInputStream(tarArchiveEntry)
+            .readNBytes((int) tarArchiveEntry.getSize());
+        return entry(tarArchiveEntry.getName(), new String(bytes, UTF_8));
     }
 }

--- a/src/test/java/nl/knaw/dans/layerstore/TarArchiveArchiveFromTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TarArchiveArchiveFromTest.java
@@ -51,6 +51,10 @@ public class TarArchiveArchiveFromTest extends AbstractTestWithTestDir {
                 entry("path/to/file3", "path/to/file3 content")
             );
         }
+        assertThat(archive.isArchived()).isTrue();
+
+        // note that LayerImpl.doArchive clears the stagingDir after calling Archive.archiveFrom
+        assertThat(stagingDir).isNotEmptyDirectory();
     }
 
     @SneakyThrows

--- a/src/test/java/nl/knaw/dans/layerstore/TarArchiveArchiveFromTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TarArchiveArchiveFromTest.java
@@ -47,6 +47,8 @@ public class TarArchiveArchiveFromTest extends AbstractTestWithTestDir {
                 getEntry(tarArchiveEntry, tar)
             )).containsExactlyInAnyOrder(
                 entry("file1", "file1 content"),
+                entry("path/", ""),
+                entry("path/to/", ""),
                 entry("path/to/file2", "path/to/file2 content"),
                 entry("path/to/file3", "path/to/file3 content")
             );

--- a/src/test/java/nl/knaw/dans/layerstore/TarArchiveArchiveFromTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TarArchiveArchiveFromTest.java
@@ -32,7 +32,7 @@ public class TarArchiveArchiveFromTest extends AbstractTestWithTestDir {
     @Test
     public void should_create_archivefile_and_change_status_to_archived() throws Exception {
         var tarFile = testDir.resolve("test.tar");
-        TarArchive tarArchive = new TarArchive(tarFile);
+        var tarArchive = new TarArchive(tarFile);
 
         // Create some files to archive
         var file1 = stagingDir.resolve("file1");
@@ -40,9 +40,9 @@ public class TarArchiveArchiveFromTest extends AbstractTestWithTestDir {
         var file3 = stagingDir.resolve("path/to/file3");
 
         // Write some string content to the files
-        String file1Content = "file1 content";
-        String file2Content = "file2 content";
-        String file3Content = "file3 content";
+        var file1Content = "file1 content";
+        var file2Content = "file2 content";
+        var file3Content = "file3 content";
         FileUtils.forceMkdir(file2.getParent().toFile());
         FileUtils.write(file1.toFile(), file1Content, "UTF-8");
         FileUtils.write(file2.toFile(), file2Content, "UTF-8");

--- a/src/test/java/nl/knaw/dans/layerstore/TarArchiveArchiveFromTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TarArchiveArchiveFromTest.java
@@ -33,9 +33,9 @@ public class TarArchiveArchiveFromTest extends AbstractTestWithTestDir {
         var archiveFile = testDir.resolve("test.tar");
         var archive = new TarArchive(archiveFile);
 
-        createStagingFileWithContent("file1");
-        createStagingFileWithContent("path/to/file2");
-        createStagingFileWithContent("path/to/file3");
+        createStagingFileWithContent("file1", "file1 content");
+        createStagingFileWithContent("path/to/file2", "path/to/file2 content");
+        createStagingFileWithContent("path/to/file3", "path/to/file3 content");
 
         // Archive the files
         archive.archiveFrom(stagingDir);

--- a/src/test/java/nl/knaw/dans/layerstore/TarArchiveFileExistsTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TarArchiveFileExistsTest.java
@@ -25,22 +25,22 @@ public class TarArchiveFileExistsTest extends AbstractTestWithTestDir {
 
     @Test
     public void should_return_file_existence_in_archive() throws Exception {
-        Path tarFile = testDir.resolve("test.tar");
-        TarArchive tarArchive = new TarArchive(tarFile);
+        Path archiveFile = testDir.resolve("test.tar");
+        TarArchive archive = new TarArchive(archiveFile);
 
         createStagingFileWithContent("file1");
         createStagingFileWithContent("path/to/file2");
 
         // Archive the files
-        tarArchive.archiveFrom(stagingDir);
+        archive.archiveFrom(stagingDir);
 
-        // Check that the tar file exists
-        assertThat(tarFile).exists();
-        assertThat(tarArchive.isArchived()).isTrue();
+        // Check that the archive file exists
+        assertThat(archiveFile).exists();
+        assertThat(archive.isArchived()).isTrue();
 
         // Check that the files are archived
-        assertThat(tarArchive.fileExists("file1")).isTrue();
-        assertThat(tarArchive.fileExists("path/to/file2")).isTrue();
-        assertThat(tarArchive.fileExists("path/to/file3")).isFalse();
+        assertThat(archive.fileExists("file1")).isTrue();
+        assertThat(archive.fileExists("path/to/file2")).isTrue();
+        assertThat(archive.fileExists("path/to/file3")).isFalse();
     }
 }

--- a/src/test/java/nl/knaw/dans/layerstore/TarArchiveFileExistsTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TarArchiveFileExistsTest.java
@@ -15,16 +15,13 @@
  */
 package nl.knaw.dans.layerstore;
 
-import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TarArchiveFileExistsTest extends AbstractTestWithTestDir {
-
 
     @Test
     public void should_return_file_existence_in_archive() throws Exception {

--- a/src/test/java/nl/knaw/dans/layerstore/TarArchiveFileExistsTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TarArchiveFileExistsTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.layerstore;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TarArchiveFileExistsTest extends AbstractTestWithTestDir {
+
+
+    @Test
+    public void should_return_file_existence_in_archive() throws Exception {
+        Path tarFile = testDir.resolve("test.tar");
+        TarArchive tarArchive = new TarArchive(tarFile);
+
+        createStagingFileWithContent("file1");
+        createStagingFileWithContent("path/to/file2");
+
+        // Archive the files
+        tarArchive.archiveFrom(stagingDir);
+
+        // Check that the tar file exists
+        assertThat(tarFile).exists();
+        assertThat(tarArchive.isArchived()).isTrue();
+
+        // Check that the files are archived
+        assertThat(tarArchive.fileExists("file1")).isTrue();
+        assertThat(tarArchive.fileExists("path/to/file2")).isTrue();
+        assertThat(tarArchive.fileExists("path/to/file3")).isFalse();
+    }
+}

--- a/src/test/java/nl/knaw/dans/layerstore/TarArchiveFileExistsTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TarArchiveFileExistsTest.java
@@ -43,4 +43,10 @@ public class TarArchiveFileExistsTest extends AbstractTestWithTestDir {
         assertThat(archive.fileExists("path/to/file2")).isTrue();
         assertThat(archive.fileExists("path/to/file3")).isFalse();
     }
+
+    @Test
+    public void should_return_false_if_the_archive_does_not_exist() {
+        var archive = new TarArchive(Path.of("does-not-exist"));
+        assertThat(archive.fileExists("xx")).isFalse();
+    }
 }

--- a/src/test/java/nl/knaw/dans/layerstore/TarArchiveFileExistsTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TarArchiveFileExistsTest.java
@@ -28,8 +28,8 @@ public class TarArchiveFileExistsTest extends AbstractTestWithTestDir {
         Path archiveFile = testDir.resolve("test.tar");
         TarArchive archive = new TarArchive(archiveFile);
 
-        createStagingFileWithContent("file1");
-        createStagingFileWithContent("path/to/file2");
+        createStagingFileWithContent("file1", "file1 content");
+        createStagingFileWithContent("path/to/file2", "path/to/file2 content");
 
         // Archive the files
         archive.archiveFrom(stagingDir);

--- a/src/test/java/nl/knaw/dans/layerstore/TarArchiveIsArchivedTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TarArchiveIsArchivedTest.java
@@ -20,11 +20,12 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-public class ZipArchiveIsArchivedTest extends AbstractTestWithTestDir {
+public class TarArchiveIsArchivedTest extends AbstractTestWithTestDir {
     @Test
     public void should_change_status_to_archived() throws Exception {
         FileUtils.forceMkdir(testDir.toFile());
-        var archive = new ZipArchive(testDir.resolve("test.zip"));
+        FileUtils.forceMkdir(stagingDir.toFile());
+        var archive = new TarArchive(testDir.resolve("test.tar"));
         archive.archiveFrom(stagingDir);
 
         assertThat(archive.isArchived()).isTrue();

--- a/src/test/java/nl/knaw/dans/layerstore/TarArchiveIsArchivedTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TarArchiveIsArchivedTest.java
@@ -23,7 +23,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 public class TarArchiveIsArchivedTest extends AbstractTestWithTestDir {
     @Test
     public void should_change_status_to_archived() throws Exception {
-        FileUtils.forceMkdir(testDir.toFile());
         FileUtils.forceMkdir(stagingDir.toFile());
         var archive = new TarArchive(testDir.resolve("test.tar"));
         archive.archiveFrom(stagingDir);

--- a/src/test/java/nl/knaw/dans/layerstore/TarArchiveReadFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TarArchiveReadFileTest.java
@@ -28,21 +28,21 @@ public class TarArchiveReadFileTest extends AbstractTestWithTestDir {
 
     @Test
     public void should_return_content_of_file_in_archive() throws Exception {
-        TarArchive tarArchive = new TarArchive(tarFile);
+        TarArchive archive = new TarArchive(tarFile);
 
         createStagingFileWithContent("file1");
         createStagingFileWithContent("path/to/file2");
         createStagingFileWithContent("path/to/file3");
 
         // Archive the files
-        tarArchive.archiveFrom(stagingDir);
+        archive.archiveFrom(stagingDir);
 
         // Check that the tar file exists
         assertThat(tarFile).exists();
-        assertThat(tarArchive.isArchived()).isTrue();
+        assertThat(archive.isArchived()).isTrue();
 
         // Check that the content is archived
-        try (var inputStream = tarArchive.readFile("path/to/file2")) {
+        try (var inputStream = archive.readFile("path/to/file2")) {
             assertThat(inputStream.readAllBytes())
                 .isEqualTo("path/to/file2 content".getBytes());
         }
@@ -51,20 +51,20 @@ public class TarArchiveReadFileTest extends AbstractTestWithTestDir {
     @Test
     @SuppressWarnings("resource") // for assertThatThrownBy
     public void should_throw_when_reading_file_not_in_archive() throws Exception {
-        TarArchive tarArchive = new TarArchive(tarFile);
+        TarArchive archive = new TarArchive(tarFile);
 
         createStagingFileWithContent("file1");
         createStagingFileWithContent("path/to/file3");
 
         // Archive the files
-        tarArchive.archiveFrom(stagingDir);
+        archive.archiveFrom(stagingDir);
 
         // Check that the tar file exists
         assertThat(tarFile).exists();
-        assertThat(tarArchive.isArchived()).isTrue();
+        assertThat(archive.isArchived()).isTrue();
 
-        // Check that the content is archived
-        assertThatThrownBy(() -> tarArchive.readFile("path/to/file2").readAllBytes())
+        // Read the content of a file that is not in the archive
+        assertThatThrownBy(() -> archive.readFile("path/to/file2").readAllBytes())
             .isInstanceOf(IOException.class)
             .hasMessage("path/to/file2 not found in target/test/TarArchiveReadFileTest/test.tar");
     }

--- a/src/test/java/nl/knaw/dans/layerstore/TarArchiveReadFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TarArchiveReadFileTest.java
@@ -27,7 +27,7 @@ public class TarArchiveReadFileTest extends AbstractTestWithTestDir {
     Path tarFile = testDir.resolve("test.tar");
 
     @Test
-    public void should_content_of_file__in_archive() throws Exception {
+    public void should_return_content_of_file_in_archive() throws Exception {
         TarArchive tarArchive = new TarArchive(tarFile);
 
         createStagingFileWithContent("file1");
@@ -66,6 +66,6 @@ public class TarArchiveReadFileTest extends AbstractTestWithTestDir {
         // Check that the content is archived
         assertThatThrownBy(() -> tarArchive.readFile("path/to/file2").readAllBytes())
             .isInstanceOf(IOException.class)
-            .hasMessage("File not found in tar archive: path/to/file2");
+            .hasMessage("path/to/file2 not found in target/test/TarArchiveReadFileTest/test.tar");
     }
 }

--- a/src/test/java/nl/knaw/dans/layerstore/TarArchiveReadFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TarArchiveReadFileTest.java
@@ -30,9 +30,9 @@ public class TarArchiveReadFileTest extends AbstractTestWithTestDir {
     public void should_return_content_of_file_in_archive() throws Exception {
         TarArchive archive = new TarArchive(tarFile);
 
-        createStagingFileWithContent("file1");
-        createStagingFileWithContent("path/to/file2");
-        createStagingFileWithContent("path/to/file3");
+        createStagingFileWithContent("file1", "file1 content");
+        createStagingFileWithContent("path/to/file2", "path/to/file2 content");
+        createStagingFileWithContent("path/to/file3", "path/to/file3 content");
 
         // Archive the files
         archive.archiveFrom(stagingDir);
@@ -53,8 +53,8 @@ public class TarArchiveReadFileTest extends AbstractTestWithTestDir {
     public void should_throw_when_reading_file_not_in_archive() throws Exception {
         TarArchive archive = new TarArchive(tarFile);
 
-        createStagingFileWithContent("file1");
-        createStagingFileWithContent("path/to/file3");
+        createStagingFileWithContent("file1", "file1 content");
+        createStagingFileWithContent("path/to/file3", "path/to/file3 content");
 
         // Archive the files
         archive.archiveFrom(stagingDir);

--- a/src/test/java/nl/knaw/dans/layerstore/TarArchiveReadFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TarArchiveReadFileTest.java
@@ -15,5 +15,55 @@
  */
 package nl.knaw.dans.layerstore;
 
-public class TarArchiveReadFileTest {
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TarArchiveReadFileTest extends AbstractTestWithTestDir {
+    Path tarFile = testDir.resolve("test.tar");
+
+    @Test
+    public void should_content_of_file__in_archive() throws Exception {
+        TarArchive tarArchive = new TarArchive(tarFile);
+
+        createStagingFileWithContent("file1");
+        createStagingFileWithContent("path/to/file2");
+        createStagingFileWithContent("path/to/file3");
+
+        // Archive the files
+        tarArchive.archiveFrom(stagingDir);
+
+        // Check that the tar file exists
+        assertThat(tarFile).exists();
+        assertThat(tarArchive.isArchived()).isTrue();
+
+        // Check that the content is archived
+        assertThat(tarArchive.readFile("path/to/file2").readAllBytes())
+            .isEqualTo("path/to/file2 content".getBytes());
+    }
+
+    @Test
+    public void should_throw_when_reading_file_not_in_archive() throws Exception {
+        TarArchive tarArchive = new TarArchive(tarFile);
+
+        createStagingFileWithContent("file1");
+        createStagingFileWithContent("path/to/file3");
+
+        // Archive the files
+        tarArchive.archiveFrom(stagingDir);
+
+        // Check that the tar file exists
+        assertThat(tarFile).exists();
+        assertThat(tarArchive.isArchived()).isTrue();
+
+        // Check that the content is archived
+        assertThatThrownBy(() -> tarArchive.readFile("path/to/file2").readAllBytes())
+            .isInstanceOf(IOException.class)
+            .hasMessage("File not found in tar archive: path/to/file2");
+    }
 }

--- a/src/test/java/nl/knaw/dans/layerstore/TarArchiveReadFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TarArchiveReadFileTest.java
@@ -33,6 +33,7 @@ public class TarArchiveReadFileTest extends AbstractTestWithTestDir {
         createStagingFileWithContent("file1", "file1 content");
         createStagingFileWithContent("path/to/file2", "path/to/file2 content");
         createStagingFileWithContent("path/to/file3", "path/to/file3 content");
+        createStagingFileWithContent("another/path/to/file2", "another/path/to/file2 content");
 
         // Archive the files
         archive.archiveFrom(stagingDir);

--- a/src/test/java/nl/knaw/dans/layerstore/TarArchiveReadFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TarArchiveReadFileTest.java
@@ -15,7 +15,6 @@
  */
 package nl.knaw.dans.layerstore;
 
-import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -43,11 +42,14 @@ public class TarArchiveReadFileTest extends AbstractTestWithTestDir {
         assertThat(tarArchive.isArchived()).isTrue();
 
         // Check that the content is archived
-        assertThat(tarArchive.readFile("path/to/file2").readAllBytes())
-            .isEqualTo("path/to/file2 content".getBytes());
+        try (var inputStream = tarArchive.readFile("path/to/file2")) {
+            assertThat(inputStream.readAllBytes())
+                .isEqualTo("path/to/file2 content".getBytes());
+        }
     }
 
     @Test
+    @SuppressWarnings("resource") // for assertThatThrownBy
     public void should_throw_when_reading_file_not_in_archive() throws Exception {
         TarArchive tarArchive = new TarArchive(tarFile);
 

--- a/src/test/java/nl/knaw/dans/layerstore/TarArchiveUnarchiveToTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TarArchiveUnarchiveToTest.java
@@ -38,13 +38,10 @@ public class TarArchiveUnarchiveToTest extends AbstractTestWithTestDir {
         var file3 = testDir.resolve("staging/path/to/file3");
 
         // Write some string content to the files
-        var file1Content = "file1 content";
-        var file2Content = "file2 content";
-        var file3Content = "file3 content";
         FileUtils.forceMkdir(file2.getParent().toFile());
-        FileUtils.write(file1.toFile(), file1Content, "UTF-8");
-        FileUtils.write(file2.toFile(), file2Content, "UTF-8");
-        FileUtils.write(file3.toFile(), file3Content, "UTF-8");
+        FileUtils.write(file1.toFile(), "file1 content", "UTF-8");
+        FileUtils.write(file2.toFile(), "file2 content", "UTF-8");
+        FileUtils.write(file3.toFile(), "file3 content", "UTF-8");
         Files.createDirectories(testDir.resolve("layer_staging"));
 
         // Archive the files
@@ -55,12 +52,13 @@ public class TarArchiveUnarchiveToTest extends AbstractTestWithTestDir {
         AssertionsForClassTypes.assertThat(tarArchive.isArchived()).isTrue();
 
         // Unarchive the files
-        tarArchive.unarchiveTo(testDir.resolve("unarchived"));
+        var unarchived = testDir.resolve("unarchived");
+        tarArchive.unarchiveTo(unarchived);
 
         // Check that the files are unarchived
-        assertThat(file1).exists();
-        assertThat(file2).exists();
-        assertThat(file3).exists();
+        assertThat(unarchived.resolve("file1")).exists();
+        assertThat(unarchived.resolve("path/to/file2")).exists();
+        assertThat(unarchived.resolve("path/to/file3")).exists();
     }
 
     @Test

--- a/src/test/java/nl/knaw/dans/layerstore/TarArchiveUnarchiveToTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TarArchiveUnarchiveToTest.java
@@ -19,7 +19,6 @@ import org.apache.commons.io.FileUtils;
 import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.Test;
 
-import java.io.FileNotFoundException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;

--- a/src/test/java/nl/knaw/dans/layerstore/TarArchiveUnarchiveToTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TarArchiveUnarchiveToTest.java
@@ -113,7 +113,7 @@ public class TarArchiveUnarchiveToTest extends AbstractTestWithTestDir {
         var unarchived = testDir.resolve("unarchived");
         assertThatThrownBy(() -> archive.unarchiveTo(unarchived))
             .hasCauseInstanceOf(IOException.class)
-            .hasRootCauseMessage("Detected Zip Slip: ../target/test/ZipArchiveUnarchiveToTest/violating/path/ in target/test/ZipArchiveUnarchiveToTest/test.tar");
+            .hasRootCauseMessage("Detected Zip Slip: ../target/test/TarArchiveUnarchiveToTest/violating/path/ in target/test/TarArchiveUnarchiveToTest/test.tar");
     }
 
     @Test

--- a/src/test/java/nl/knaw/dans/layerstore/TarArchiveUnarchiveToTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TarArchiveUnarchiveToTest.java
@@ -15,5 +15,96 @@
  */
 package nl.knaw.dans.layerstore;
 
-public class TarArchiveUnarchiveToTest {
+import org.apache.commons.io.FileUtils;
+import org.assertj.core.api.AssertionsForClassTypes;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+
+import static nl.knaw.dans.layerstore.TestUtils.assumeNotYetFixed;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+public class TarArchiveUnarchiveToTest extends AbstractTestWithTestDir {
+    @Test
+    public void should_unarchive_tarfile() throws Exception {
+        var tarFile = testDir.resolve("test.tar");
+        var tarArchive = new TarArchive(tarFile);
+        // Create some files to archive
+        var file1 = testDir.resolve("staging/file1");
+        var file2 = testDir.resolve("staging/path/to/file2");
+        var file3 = testDir.resolve("staging/path/to/file3");
+
+        // Write some string content to the files
+        var file1Content = "file1 content";
+        var file2Content = "file2 content";
+        var file3Content = "file3 content";
+        FileUtils.forceMkdir(file2.getParent().toFile());
+        FileUtils.write(file1.toFile(), file1Content, "UTF-8");
+        FileUtils.write(file2.toFile(), file2Content, "UTF-8");
+        FileUtils.write(file3.toFile(), file3Content, "UTF-8");
+        Files.createDirectories(testDir.resolve("layer_staging"));
+
+        // Archive the files
+        tarArchive.archiveFrom(stagingDir);
+
+        // Check that the tar file exists
+        assertThat(tarFile).exists();
+        AssertionsForClassTypes.assertThat(tarArchive.isArchived()).isTrue();
+
+        // Unarchive the files
+        tarArchive.unarchiveTo(testDir.resolve("unarchived"));
+
+        // Check that the files are unarchived
+        assertThat(file1).exists();
+        assertThat(file2).exists();
+        assertThat(file3).exists();
+    }
+
+    @Test
+    public void should_unarchive_tarfile_with_empty_directory() throws Exception {
+        var tarFile = testDir.resolve("test.tar");
+        var tarArchive = new TarArchive(tarFile);
+        // Create an empty directory to archive
+        Path emptyDir = testDir.resolve("staging/emptyDir");
+        FileUtils.forceMkdir(emptyDir.toFile());
+        Files.createDirectories(testDir.resolve("layer_staging"));
+
+        // Archive the empty directory
+        tarArchive.archiveFrom(stagingDir);
+
+        // Unarchive the files
+        tarArchive.unarchiveTo(testDir.resolve("unarchived"));
+        assertThat(emptyDir).exists();
+    }
+
+    @Test
+    public void should_throw_exception_when_unarchiving_non_existing_tarfile() {
+        var tarFile = testDir.resolve("non-existing.tar");
+        var tarArchive = new TarArchive(tarFile);
+        assertThat(tarFile).doesNotExist();
+        assertThat(tarArchive.isArchived()).isFalse();
+        assertThatThrownBy(() -> tarArchive.unarchiveTo(testDir.resolve("unarchived")))
+            .isInstanceOf(NoSuchFileException.class)
+            .hasMessage("target/test/TarArchiveUnarchiveToTest/non-existing.tar");
+    }
+
+    @Test
+    public void should_throw_exception_when_unarchiving_to_non_empty_directory() throws Exception {
+        var tarFile = testDir.resolve("test.tar");
+        var tarArchive = new TarArchive(tarFile);
+        // Create a files to archive
+        Files.createDirectories(testDir.resolve("staging"));
+        Files.createDirectories(testDir.resolve("layer_staging"));
+        Files.writeString(testDir.resolve("staging/file1"), "file1 content");
+        tarArchive.archiveFrom(stagingDir);
+
+        Files.createDirectories(testDir.resolve("unarchived/content"));
+
+        assumeNotYetFixed("unarchiveTo does not check if the target directory exists");
+        assertThatThrownBy(() -> tarArchive.unarchiveTo(testDir.resolve("unarchived")));
+    }
 }

--- a/src/test/java/nl/knaw/dans/layerstore/TarArchiveUnarchiveToTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TarArchiveUnarchiveToTest.java
@@ -85,8 +85,11 @@ public class TarArchiveUnarchiveToTest extends AbstractTestWithTestDir {
         assertThat(tarFile).doesNotExist();
         assertThat(tarArchive.isArchived()).isFalse();
         assertThatThrownBy(() -> tarArchive.unarchiveTo(testDir.resolve("unarchived")))
-            .isInstanceOf(NoSuchFileException.class)
-            .hasMessage("target/test/TarArchiveUnarchiveToTest/non-existing.tar");
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage("Could not unarchive target/test/TarArchiveUnarchiveToTest/non-existing.tar")
+            .hasCauseInstanceOf(NoSuchFileException.class)
+            .hasRootCauseMessage("target/test/TarArchiveUnarchiveToTest/non-existing.tar");
+
     }
 
     @Test

--- a/src/test/java/nl/knaw/dans/layerstore/TarArchiveUnarchiveToTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TarArchiveUnarchiveToTest.java
@@ -35,22 +35,22 @@ public class TarArchiveUnarchiveToTest extends AbstractTestWithTestDir {
     @Test
     public void should_unarchive_tarfile() throws Exception {
         var tarFile = testDir.resolve("test.tar");
-        var tarArchive = new TarArchive(tarFile);
+        var archive = new TarArchive(tarFile);
 
         createStagingFileWithContent("file1", "file1 content");
         createStagingFileWithContent("path/to/file2", "path/to/file2 content");
         createStagingFileWithContent("path/to/file3", "path/to/file3 content");
 
         // Archive the files
-        tarArchive.archiveFrom(stagingDir);
+        archive.archiveFrom(stagingDir);
 
         // Check that the tar file exists
         assertThat(tarFile).exists();
-        AssertionsForClassTypes.assertThat(tarArchive.isArchived()).isTrue();
+        AssertionsForClassTypes.assertThat(archive.isArchived()).isTrue();
 
         // Unarchive the files
         var unarchived = testDir.resolve("unarchived");
-        tarArchive.unarchiveTo(unarchived);
+        archive.unarchiveTo(unarchived);
 
         // Check that the files are unarchived
         assertThat(unarchived.resolve("file1")).exists();
@@ -61,16 +61,16 @@ public class TarArchiveUnarchiveToTest extends AbstractTestWithTestDir {
     @Test
     public void should_unarchive_tarfile_with_empty_directory() throws Exception {
         var tarFile = testDir.resolve("test.tar");
-        var tarArchive = new TarArchive(tarFile);
+        var archive = new TarArchive(tarFile);
         // Create an empty directory to archive
         Path emptyDir = stagingDir.resolve("emptyDir");
         FileUtils.forceMkdir(emptyDir.toFile());
 
         // Archive the empty directory
-        tarArchive.archiveFrom(stagingDir);
+        archive.archiveFrom(stagingDir);
 
         // Unarchive the files
-        tarArchive.unarchiveTo(testDir.resolve("unarchived"));
+        archive.unarchiveTo(testDir.resolve("unarchived"));
         assertThat(emptyDir).exists();
     }
 
@@ -89,12 +89,12 @@ public class TarArchiveUnarchiveToTest extends AbstractTestWithTestDir {
         AssertionsForClassTypes.assertThat(archive.isArchived()).isTrue();
 
         // add malicious file to the archive
-        try (var zip = new TarArchiveOutputStream(new FileOutputStream(tarFile.toFile()))) {
+        try (var tar = new TarArchiveOutputStream(new FileOutputStream(tarFile.toFile()))) {
             var maliciousDir = testDir.resolve("violating/path");
             Files.createDirectories(maliciousDir);
             var entry = new TarArchiveEntry(maliciousDir, "../" + maliciousDir);
-            zip.putArchiveEntry(entry);
-            zip.closeArchiveEntry();
+            tar.putArchiveEntry(entry);
+            tar.closeArchiveEntry();
         }
 
         // Unarchive the files
@@ -107,10 +107,10 @@ public class TarArchiveUnarchiveToTest extends AbstractTestWithTestDir {
     @Test
     public void should_throw_exception_when_unarchiving_non_existing_tarfile() {
         var tarFile = testDir.resolve("non-existing.tar");
-        var tarArchive = new TarArchive(tarFile);
+        var archive = new TarArchive(tarFile);
         assertThat(tarFile).doesNotExist();
-        assertThat(tarArchive.isArchived()).isFalse();
-        assertThatThrownBy(() -> tarArchive.unarchiveTo(testDir.resolve("unarchived")))
+        assertThat(archive.isArchived()).isFalse();
+        assertThatThrownBy(() -> archive.unarchiveTo(testDir.resolve("unarchived")))
             .isInstanceOf(RuntimeException.class)
             .hasMessage("Could not unarchive target/test/TarArchiveUnarchiveToTest/non-existing.tar")
             .hasCauseInstanceOf(NoSuchFileException.class)
@@ -121,15 +121,15 @@ public class TarArchiveUnarchiveToTest extends AbstractTestWithTestDir {
     @Test
     public void should_throw_exception_when_unarchiving_to_non_empty_directory() throws Exception {
         var tarFile = testDir.resolve("test.tar");
-        var tarArchive = new TarArchive(tarFile);
+        var archive = new TarArchive(tarFile);
         // Create a file to archive
         Files.createDirectories(stagingDir);
         Files.writeString(stagingDir.resolve("file1"), "file1 content");
-        tarArchive.archiveFrom(stagingDir);
+        archive.archiveFrom(stagingDir);
 
         Files.createDirectories(testDir.resolve("unarchived/content"));
 
         assumeNotYetFixed("unarchiveTo does not check if the target directory exists");
-        assertThatThrownBy(() -> tarArchive.unarchiveTo(testDir.resolve("unarchived")));
+        assertThatThrownBy(() -> archive.unarchiveTo(testDir.resolve("unarchived")));
     }
 }

--- a/src/test/java/nl/knaw/dans/layerstore/TarArchiveUnarchiveToTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TarArchiveUnarchiveToTest.java
@@ -19,6 +19,7 @@ import org.apache.commons.io.FileUtils;
 import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.Test;
 
+import java.io.FileNotFoundException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
@@ -33,9 +34,9 @@ public class TarArchiveUnarchiveToTest extends AbstractTestWithTestDir {
         var tarFile = testDir.resolve("test.tar");
         var tarArchive = new TarArchive(tarFile);
         // Create some files to archive
-        var file1 = testDir.resolve("staging/file1");
-        var file2 = testDir.resolve("staging/path/to/file2");
-        var file3 = testDir.resolve("staging/path/to/file3");
+        var file1 = stagingDir.resolve("file1");
+        var file2 = stagingDir.resolve("path/to/file2");
+        var file3 = stagingDir.resolve("path/to/file3");
 
         // Write some string content to the files
         FileUtils.forceMkdir(file2.getParent().toFile());

--- a/src/test/java/nl/knaw/dans/layerstore/TarArchiveUnarchiveToTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TarArchiveUnarchiveToTest.java
@@ -19,7 +19,6 @@ import org.apache.commons.io.FileUtils;
 import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;

--- a/src/test/java/nl/knaw/dans/layerstore/TarArchiveUnarchiveToTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TarArchiveUnarchiveToTest.java
@@ -36,17 +36,10 @@ public class TarArchiveUnarchiveToTest extends AbstractTestWithTestDir {
     public void should_unarchive_tarfile() throws Exception {
         var tarFile = testDir.resolve("test.tar");
         var tarArchive = new TarArchive(tarFile);
-        // Create some files to archive
-        var file1 = stagingDir.resolve("file1");
-        var file2 = stagingDir.resolve("path/to/file2");
-        var file3 = stagingDir.resolve("path/to/file3");
 
-        // Write some string content to the files
-        FileUtils.forceMkdir(file2.getParent().toFile());
-        FileUtils.write(file1.toFile(), "file1 content", "UTF-8");
-        FileUtils.write(file2.toFile(), "file2 content", "UTF-8");
-        FileUtils.write(file3.toFile(), "file3 content", "UTF-8");
-        Files.createDirectories(testDir.resolve("layer_staging"));
+        createStagingFileWithContent("file1", "file1 content");
+        createStagingFileWithContent("path/to/file2", "path/to/file2 content");
+        createStagingFileWithContent("path/to/file3", "path/to/file3 content");
 
         // Archive the files
         tarArchive.archiveFrom(stagingDir);
@@ -70,9 +63,8 @@ public class TarArchiveUnarchiveToTest extends AbstractTestWithTestDir {
         var tarFile = testDir.resolve("test.tar");
         var tarArchive = new TarArchive(tarFile);
         // Create an empty directory to archive
-        Path emptyDir = testDir.resolve("staging/emptyDir");
+        Path emptyDir = stagingDir.resolve("emptyDir");
         FileUtils.forceMkdir(emptyDir.toFile());
-        Files.createDirectories(testDir.resolve("layer_staging"));
 
         // Archive the empty directory
         tarArchive.archiveFrom(stagingDir);
@@ -86,12 +78,8 @@ public class TarArchiveUnarchiveToTest extends AbstractTestWithTestDir {
     public void should_report_zip_slip() throws Exception {
         var tarFile = testDir.resolve("test.tar");
         var archive = new TarArchive(tarFile);
-        // Create some files to archive
-        var file1 = stagingDir.resolve("file1");
 
-        // Write some string content to the files
-        FileUtils.write(file1.toFile(), "file1 content", "UTF-8");
-        Files.createDirectories(testDir.resolve("layer_staging"));
+        createStagingFileWithContent("file1", "file1 content");
 
         // Archive the files
         archive.archiveFrom(stagingDir);
@@ -134,10 +122,9 @@ public class TarArchiveUnarchiveToTest extends AbstractTestWithTestDir {
     public void should_throw_exception_when_unarchiving_to_non_empty_directory() throws Exception {
         var tarFile = testDir.resolve("test.tar");
         var tarArchive = new TarArchive(tarFile);
-        // Create a files to archive
-        Files.createDirectories(testDir.resolve("staging"));
-        Files.createDirectories(testDir.resolve("layer_staging"));
-        Files.writeString(testDir.resolve("staging/file1"), "file1 content");
+        // Create a file to archive
+        Files.createDirectories(stagingDir);
+        Files.writeString(stagingDir.resolve("file1"), "file1 content");
         tarArchive.archiveFrom(stagingDir);
 
         Files.createDirectories(testDir.resolve("unarchived/content"));

--- a/src/test/java/nl/knaw/dans/layerstore/TestUtils.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TestUtils.java
@@ -28,6 +28,7 @@ import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class TestUtils {
@@ -59,9 +60,10 @@ public class TestUtils {
     static ZipFile zipFileFrom(Path zipFile) throws IOException {
         // replaces deprecated constructor
         return ZipFile.builder()
-            .setSeekableByteChannel(Files.newByteChannel(zipFile))
+            .setCharset(UTF_8)
             .setUseUnicodeExtraFields(true)
             .setIgnoreLocalFileHeader(false)
+            .setFile(zipFile.toFile())
             .get();
     }
 }

--- a/src/test/java/nl/knaw/dans/layerstore/TestUtils.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TestUtils.java
@@ -54,14 +54,4 @@ public class TestUtils {
     public static void assumeNotYetFixed(String message) {
         assumeTrue(false, message);
     }
-
-    static ZipFile zipFileFrom(Path zipFile) throws IOException {
-        // replaces deprecated constructor
-        return ZipFile.builder()
-            .setCharset(UTF_8)
-            .setUseUnicodeExtraFields(true)
-            .setIgnoreLocalFileHeader(false)
-            .setFile(zipFile.toFile())
-            .get();
-    }
 }

--- a/src/test/java/nl/knaw/dans/layerstore/TestUtils.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TestUtils.java
@@ -19,15 +19,11 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
-import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.PrintStream;
-import java.nio.file.Path;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class TestUtils {

--- a/src/test/java/nl/knaw/dans/layerstore/TestUtils.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TestUtils.java
@@ -15,32 +15,9 @@
  */
 package nl.knaw.dans.layerstore;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.read.ListAppender;
-import org.slf4j.LoggerFactory;
-
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class TestUtils {
-    public static ListAppender<ILoggingEvent> captureLog() {
-        var logger = (Logger) LoggerFactory.getLogger(LayerManagerImpl.class);
-        ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
-        listAppender.start();
-        logger.setLevel(Level.ERROR);
-        logger.addAppender(listAppender);
-        return listAppender;
-    }
-
-    public static ByteArrayOutputStream captureStdout() {
-        var outContent = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(outContent));
-        return outContent;
-    }
 
     /**
      * Assume that a bug is not yet fixed. This allows to execute as much of a test as possible to show code coverage, without creating false positives or false negatives.

--- a/src/test/java/nl/knaw/dans/layerstore/TestUtils.java
+++ b/src/test/java/nl/knaw/dans/layerstore/TestUtils.java
@@ -25,7 +25,6 @@ import org.slf4j.LoggerFactory;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -48,8 +47,7 @@ public class TestUtils {
     }
 
     /**
-     * Assume that a bug is not yet fixed. This allows to execute as much of a test as possible
-     * to show code coverage, without creating false positives or false negatives.
+     * Assume that a bug is not yet fixed. This allows to execute as much of a test as possible to show code coverage, without creating false positives or false negatives.
      *
      * @param message the message to display
      */

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveArchiveFromTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveArchiveFromTest.java
@@ -26,24 +26,23 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 public class ZipArchiveArchiveFromTest extends AbstractTestWithTestDir {
     @Test
     public void should_create_zipfile_and_change_status_to_archived() throws Exception {
-        var zipFile = testDir.resolve("test.zip");
-        var zipArchive = new ZipArchive(zipFile);
+        var archiveFile = testDir.resolve("test.zip");
+        var archive = new ZipArchive(archiveFile);
 
         createStagingFileWithContent("file1");
         createStagingFileWithContent("path/to/file2");
         createStagingFileWithContent("path/to/file3");
 
         // Archive the files
-        zipArchive.archiveFrom(stagingDir);
+        archive.archiveFrom(stagingDir);
 
         // Check that the zip file exists and contains the files and not more than that
-        assertThat(zipFile).exists();
-        try (var zip = zipFileFrom(zipFile)) {
+        assertThat(archiveFile).exists();
+        try (var zip = zipFileFrom(archiveFile)) {
             assertThat(Collections.list(zip.getEntries()).stream().map(ZipArchiveEntry::getName))
                 .containsExactlyInAnyOrder("file1", "path/to/file2", "path/to/file3", "path/", "path/to/");
         }
-
-        assertThat(zipArchive.isArchived()).isTrue();
+        assertThat(archive.isArchived()).isTrue();
 
         // note that LayerImpl.doArchive clears the stagingDir after calling Archive.archiveFrom
         assertThat(stagingDir).isNotEmptyDirectory();

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveArchiveFromTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveArchiveFromTest.java
@@ -28,16 +28,16 @@ public class ZipArchiveArchiveFromTest extends AbstractTestWithTestDir {
     @Test
     public void should_create_zipfile_and_change_status_to_archived() throws Exception {
         var zipFile = testDir.resolve("test.zip");
-        ZipArchive zipArchive = new ZipArchive(zipFile);
+        var zipArchive = new ZipArchive(zipFile);
         // Create some files to archive
-        Path file1 = stagingDir.resolve("file1");
-        Path file2 = stagingDir.resolve("path/to/file2");
-        Path file3 = stagingDir.resolve("path/to/file3");
+        var file1 = stagingDir.resolve("file1");
+        var file2 = stagingDir.resolve("path/to/file2");
+        var file3 = stagingDir.resolve("path/to/file3");
 
         // Write some string content to the files
-        String file1Content = "file1 content";
-        String file2Content = "file2 content";
-        String file3Content = "file3 content";
+        var file1Content = "file1 content";
+        var file2Content = "file2 content";
+        var file3Content = "file3 content";
         FileUtils.forceMkdir(file2.getParent().toFile());
         FileUtils.write(file1.toFile(), file1Content, "UTF-8");
         FileUtils.write(file2.toFile(), file2Content, "UTF-8");

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveArchiveFromTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveArchiveFromTest.java
@@ -15,10 +15,9 @@
  */
 package nl.knaw.dans.layerstore;
 
-import org.apache.commons.io.FileUtils;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.junit.jupiter.api.Test;
 
-import java.nio.file.Path;
 import java.util.Collections;
 
 import static nl.knaw.dans.layerstore.TestUtils.zipFileFrom;
@@ -29,33 +28,18 @@ public class ZipArchiveArchiveFromTest extends AbstractTestWithTestDir {
     public void should_create_zipfile_and_change_status_to_archived() throws Exception {
         var zipFile = testDir.resolve("test.zip");
         var zipArchive = new ZipArchive(zipFile);
-        // Create some files to archive
-        var file1 = stagingDir.resolve("file1");
-        var file2 = stagingDir.resolve("path/to/file2");
-        var file3 = stagingDir.resolve("path/to/file3");
 
-        // Write some string content to the files
-        var file1Content = "file1 content";
-        var file2Content = "file2 content";
-        var file3Content = "file3 content";
-        FileUtils.forceMkdir(file2.getParent().toFile());
-        FileUtils.write(file1.toFile(), file1Content, "UTF-8");
-        FileUtils.write(file2.toFile(), file2Content, "UTF-8");
-        FileUtils.write(file3.toFile(), file3Content, "UTF-8");
+        createStagingFileWithContent("file1");
+        createStagingFileWithContent("path/to/file2");
+        createStagingFileWithContent("path/to/file3");
 
         // Archive the files
         zipArchive.archiveFrom(stagingDir);
 
         // Check that the zip file exists and contains the files and not more than that
         assertThat(zipFile).exists();
-        try (var zf = zipFileFrom(zipFile)) {
-            assertThat(zf.getEntry("file1")).isNotNull();
-            assertThat(zf.getEntry("path/to/file2")).isNotNull();
-            assertThat(zf.getEntry("path/to/file3")).isNotNull();
-
-            // 3 files + 2 directories = 5 entries
-            assertThat(Collections.list(zf.getEntries()).size()).isEqualTo(5);
-        }
+        assertThat(Collections.list(zipFileFrom(zipFile).getEntries()).stream().map(ZipArchiveEntry::getName))
+            .containsExactlyInAnyOrder("file1", "path/to/file2", "path/to/file3", "path/", "path/to/");
 
         assertThat(zipArchive.isArchived()).isTrue();
     }

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveArchiveFromTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveArchiveFromTest.java
@@ -38,9 +38,14 @@ public class ZipArchiveArchiveFromTest extends AbstractTestWithTestDir {
 
         // Check that the zip file exists and contains the files and not more than that
         assertThat(zipFile).exists();
-        assertThat(Collections.list(zipFileFrom(zipFile).getEntries()).stream().map(ZipArchiveEntry::getName))
-            .containsExactlyInAnyOrder("file1", "path/to/file2", "path/to/file3", "path/", "path/to/");
+        try (var zip = zipFileFrom(zipFile)) {
+            assertThat(Collections.list(zip.getEntries()).stream().map(ZipArchiveEntry::getName))
+                .containsExactlyInAnyOrder("file1", "path/to/file2", "path/to/file3", "path/", "path/to/");
+        }
 
         assertThat(zipArchive.isArchived()).isTrue();
+
+        // note that LayerImpl.doArchive clears the stagingDir after calling Archive.archiveFrom
+        assertThat(stagingDir).isNotEmptyDirectory();
     }
 }

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveArchiveFromTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveArchiveFromTest.java
@@ -33,9 +33,9 @@ public class ZipArchiveArchiveFromTest extends AbstractTestWithTestDir {
         var archiveFile = testDir.resolve("test.zip");
         var archive = new ZipArchive(archiveFile);
 
-        createStagingFileWithContent("file1");
-        createStagingFileWithContent("path/to/file2");
-        createStagingFileWithContent("path/to/file3");
+        createStagingFileWithContent("file1", "file1 content");
+        createStagingFileWithContent("path/to/file2", "path/to/file2 content");
+        createStagingFileWithContent("path/to/file3", "path/to/file3 content");
 
         // Archive the files
         archive.archiveFrom(stagingDir);

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveFileExistsTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveFileExistsTest.java
@@ -21,17 +21,18 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.file.Path;
 
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ZipArchiveFileExistsTest extends AbstractTestWithTestDir {
+    Path zipFile = testDir.resolve("test.zip");
+
     @Test
     public void should_return_true_when_file_exists_in_archive() throws Exception {
-        var zipFile = testDir.resolve("test.zip");
         ZipArchive zipArchive = new ZipArchive(zipFile);
 
         createFileWithContent("file1");
-        createFileWithContent("file2");
-        createFileWithContent("file3");
+        createFileWithContent("path/to/file2");
+        createFileWithContent("path/to/file3");
 
         // Archive the files
         zipArchive.archiveFrom(stagingDir);
@@ -40,15 +41,35 @@ public class ZipArchiveFileExistsTest extends AbstractTestWithTestDir {
         assertThat(zipFile).exists();
         assertThat(zipArchive.isArchived()).isTrue();
 
-        // Check that the files are unarchived
+        // Check that the files are archived
         assertThat(zipArchive.fileExists("file1")).isTrue();
         assertThat(zipArchive.fileExists("path/to/file2")).isTrue();
         assertThat(zipArchive.fileExists("path/to/file3")).isTrue();
     }
 
+    @Test
+    public void should_return_false_when_file_does_not_exiss_in_archive() throws Exception {
+        ZipArchive zipArchive = new ZipArchive(zipFile);
+
+        createFileWithContent("file1");
+        createFileWithContent("path/to/file2");
+
+        // Archive the files
+        zipArchive.archiveFrom(stagingDir);
+
+        // Check that the zip file exists
+        assertThat(zipFile).exists();
+        assertThat(zipArchive.isArchived()).isTrue();
+
+        // Check that the files are archived
+        assertThat(zipArchive.fileExists("file1")).isTrue();
+        assertThat(zipArchive.fileExists("path/to/file2")).isTrue();
+        assertThat(zipArchive.fileExists("path/to/file3")).isFalse();
+    }
+
     private void createFileWithContent(String name) throws IOException {
-        var file = stagingDir.resolve("path/to/" + name);
-        var content = name + " content";
+        var file = stagingDir.resolve(name);
+        var content = file.getFileName() + " content";
         FileUtils.forceMkdir(file.getParent().toFile());
         FileUtils.write(file.toFile(), content, "UTF-8");
     }

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveFileExistsTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveFileExistsTest.java
@@ -28,8 +28,8 @@ public class ZipArchiveFileExistsTest extends AbstractTestWithTestDir {
     public void should_return_file_existence_in_archive() throws Exception {
         ZipArchive archive = new ZipArchive(archiveFile);
 
-        createStagingFileWithContent("file1");
-        createStagingFileWithContent("path/to/file2");
+        createStagingFileWithContent("file1", "file1 content");
+        createStagingFileWithContent("path/to/file2", "path/to/file2 content");
 
         // Archive the files
         archive.archiveFrom(stagingDir);

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveFileExistsTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveFileExistsTest.java
@@ -28,14 +28,14 @@ public class ZipArchiveFileExistsTest extends AbstractTestWithTestDir {
         var zipFile = testDir.resolve("test.zip");
         ZipArchive zipArchive = new ZipArchive(zipFile);
         // Create some files to archive
-        Path file1 = stagingDir.resolve("file1");
-        Path file2 = stagingDir.resolve("path/to/file2");
-        Path file3 = stagingDir.resolve("path/to/file3");
+        var file1 = stagingDir.resolve("file1");
+        var file2 = stagingDir.resolve("path/to/file2");
+        var file3 = stagingDir.resolve("path/to/file3");
 
         // Write some string content to the files
-        String file1Content = "file1 content";
-        String file2Content = "file2 content";
-        String file3Content = "file3 content";
+        var file1Content = "file1 content";
+        var file2Content = "file2 content";
+        var file3Content = "file3 content";
         FileUtils.forceMkdir(file2.getParent().toFile());
         FileUtils.write(file1.toFile(), file1Content, "UTF-8");
         FileUtils.write(file2.toFile(), file2Content, "UTF-8");

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveFileExistsTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveFileExistsTest.java
@@ -22,46 +22,25 @@ import java.nio.file.Path;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ZipArchiveFileExistsTest extends AbstractTestWithTestDir {
-    Path zipFile = testDir.resolve("test.zip");
+    Path archiveFile = testDir.resolve("test.zip");
 
     @Test
-    public void should_return_true_when_file_exists_in_archive() throws Exception {
-        ZipArchive zipArchive = new ZipArchive(zipFile);
-
-        createStagingFileWithContent("file1");
-        createStagingFileWithContent("path/to/file2");
-        createStagingFileWithContent("path/to/file3");
-
-        // Archive the files
-        zipArchive.archiveFrom(stagingDir);
-
-        // Check that the zip file exists
-        assertThat(zipFile).exists();
-        assertThat(zipArchive.isArchived()).isTrue();
-
-        // Check that the files are archived
-        assertThat(zipArchive.fileExists("file1")).isTrue();
-        assertThat(zipArchive.fileExists("path/to/file2")).isTrue();
-        assertThat(zipArchive.fileExists("path/to/file3")).isTrue();
-    }
-
-    @Test
-    public void should_return_false_when_file_does_not_exiss_in_archive() throws Exception {
-        ZipArchive zipArchive = new ZipArchive(zipFile);
+    public void should_return_file_existence_in_archive() throws Exception {
+        ZipArchive archive = new ZipArchive(archiveFile);
 
         createStagingFileWithContent("file1");
         createStagingFileWithContent("path/to/file2");
 
         // Archive the files
-        zipArchive.archiveFrom(stagingDir);
+        archive.archiveFrom(stagingDir);
 
-        // Check that the zip file exists
-        assertThat(zipFile).exists();
-        assertThat(zipArchive.isArchived()).isTrue();
+        // Check that the archive file exists
+        assertThat(archiveFile).exists();
+        assertThat(archive.isArchived()).isTrue();
 
         // Check that the files are archived
-        assertThat(zipArchive.fileExists("file1")).isTrue();
-        assertThat(zipArchive.fileExists("path/to/file2")).isTrue();
-        assertThat(zipArchive.fileExists("path/to/file3")).isFalse();
+        assertThat(archive.fileExists("file1")).isTrue();
+        assertThat(archive.fileExists("path/to/file2")).isTrue();
+        assertThat(archive.fileExists("path/to/file3")).isFalse();
     }
 }

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveFileExistsTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveFileExistsTest.java
@@ -18,6 +18,7 @@ package nl.knaw.dans.layerstore;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.nio.file.Path;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
@@ -27,19 +28,10 @@ public class ZipArchiveFileExistsTest extends AbstractTestWithTestDir {
     public void should_return_true_when_file_exists_in_archive() throws Exception {
         var zipFile = testDir.resolve("test.zip");
         ZipArchive zipArchive = new ZipArchive(zipFile);
-        // Create some files to archive
-        var file1 = stagingDir.resolve("file1");
-        var file2 = stagingDir.resolve("path/to/file2");
-        var file3 = stagingDir.resolve("path/to/file3");
 
-        // Write some string content to the files
-        var file1Content = "file1 content";
-        var file2Content = "file2 content";
-        var file3Content = "file3 content";
-        FileUtils.forceMkdir(file2.getParent().toFile());
-        FileUtils.write(file1.toFile(), file1Content, "UTF-8");
-        FileUtils.write(file2.toFile(), file2Content, "UTF-8");
-        FileUtils.write(file3.toFile(), file3Content, "UTF-8");
+        createFileWithContent("file1");
+        createFileWithContent("file2");
+        createFileWithContent("file3");
 
         // Archive the files
         zipArchive.archiveFrom(stagingDir);
@@ -52,5 +44,12 @@ public class ZipArchiveFileExistsTest extends AbstractTestWithTestDir {
         assertThat(zipArchive.fileExists("file1")).isTrue();
         assertThat(zipArchive.fileExists("path/to/file2")).isTrue();
         assertThat(zipArchive.fileExists("path/to/file3")).isTrue();
+    }
+
+    private void createFileWithContent(String name) throws IOException {
+        var file = stagingDir.resolve("path/to/" + name);
+        var content = name + " content";
+        FileUtils.forceMkdir(file.getParent().toFile());
+        FileUtils.write(file.toFile(), content, "UTF-8");
     }
 }

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveFileExistsTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveFileExistsTest.java
@@ -15,10 +15,8 @@
  */
 package nl.knaw.dans.layerstore;
 
-import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,9 +28,9 @@ public class ZipArchiveFileExistsTest extends AbstractTestWithTestDir {
     public void should_return_true_when_file_exists_in_archive() throws Exception {
         ZipArchive zipArchive = new ZipArchive(zipFile);
 
-        createFileWithContent("file1");
-        createFileWithContent("path/to/file2");
-        createFileWithContent("path/to/file3");
+        createStagingFileWithContent("file1");
+        createStagingFileWithContent("path/to/file2");
+        createStagingFileWithContent("path/to/file3");
 
         // Archive the files
         zipArchive.archiveFrom(stagingDir);
@@ -51,8 +49,8 @@ public class ZipArchiveFileExistsTest extends AbstractTestWithTestDir {
     public void should_return_false_when_file_does_not_exiss_in_archive() throws Exception {
         ZipArchive zipArchive = new ZipArchive(zipFile);
 
-        createFileWithContent("file1");
-        createFileWithContent("path/to/file2");
+        createStagingFileWithContent("file1");
+        createStagingFileWithContent("path/to/file2");
 
         // Archive the files
         zipArchive.archiveFrom(stagingDir);
@@ -65,12 +63,5 @@ public class ZipArchiveFileExistsTest extends AbstractTestWithTestDir {
         assertThat(zipArchive.fileExists("file1")).isTrue();
         assertThat(zipArchive.fileExists("path/to/file2")).isTrue();
         assertThat(zipArchive.fileExists("path/to/file3")).isFalse();
-    }
-
-    private void createFileWithContent(String name) throws IOException {
-        var file = stagingDir.resolve(name);
-        var content = file.getFileName() + " content";
-        FileUtils.forceMkdir(file.getParent().toFile());
-        FileUtils.write(file.toFile(), content, "UTF-8");
     }
 }

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveFileExistsTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveFileExistsTest.java
@@ -43,4 +43,10 @@ public class ZipArchiveFileExistsTest extends AbstractTestWithTestDir {
         assertThat(archive.fileExists("path/to/file2")).isTrue();
         assertThat(archive.fileExists("path/to/file3")).isFalse();
     }
+
+    @Test
+    public void should_return_false_if_the_archive_does_not_exist() {
+        var archive = new ZipArchive(Path.of("does-not-exist"));
+        assertThat(archive.fileExists("xx")).isFalse();
+    }
 }

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveIsArchivedTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveIsArchivedTest.java
@@ -16,4 +16,5 @@
 package nl.knaw.dans.layerstore;
 
 public class ZipArchiveIsArchivedTest {
+    // on the flight in other ZipArchive-Tests
 }

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveIsArchivedTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveIsArchivedTest.java
@@ -15,6 +15,19 @@
  */
 package nl.knaw.dans.layerstore;
 
-public class ZipArchiveIsArchivedTest {
-    // on the flight in other ZipArchive-Tests
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class ZipArchiveIsArchivedTest extends AbstractTestWithTestDir {
+    @Test
+    public void should_change_status_to_archived() throws Exception {
+        FileUtils.forceMkdir(testDir.toFile());
+        var zipFile = testDir.resolve("test.zip");
+        var zipArchive = new ZipArchive(zipFile);
+        zipArchive.archiveFrom(stagingDir);
+
+        assertThat(zipArchive.isArchived()).isTrue();
+    }
 }

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveIsArchivedTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveIsArchivedTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 public class ZipArchiveIsArchivedTest extends AbstractTestWithTestDir {
     @Test
     public void should_change_status_to_archived() throws Exception {
-        FileUtils.forceMkdir(testDir.toFile());
+        FileUtils.forceMkdir(stagingDir.toFile());
         var archive = new ZipArchive(testDir.resolve("test.zip"));
         archive.archiveFrom(stagingDir);
 

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveReadFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveReadFileTest.java
@@ -27,6 +27,7 @@ public class ZipArchiveReadFileTest extends AbstractTestWithTestDir {
     Path zipFile = testDir.resolve("test.zip");
 
     @Test
+    @SuppressWarnings("resource") // for assertThatThrownBy
     public void should_return_content_of_file_in_archive() throws Exception {
         ZipArchive zipArchive = new ZipArchive(zipFile);
 
@@ -43,16 +44,18 @@ public class ZipArchiveReadFileTest extends AbstractTestWithTestDir {
         assertThat(zipArchive.isArchived()).isTrue();
 
         // Read the content of a file in the archive
-        assertThat(zipArchive.readFile("path/to/file2").readAllBytes())
-            .isEqualTo("path/to/file2 content".getBytes());
-
+        try (var inputStream = zipArchive.readFile("path/to/file2")) {
+            assertThat(inputStream.readAllBytes())
+                .isEqualTo("path/to/file2 content".getBytes());
+        }
         // getEntries in readFile returns only an exact match of the full path
-        assertThatThrownBy(() -> zipArchive.readFile("file2").readAllBytes())
+        assertThatThrownBy(() -> zipArchive.readFile("file2"))
             .isInstanceOf(FileNotFoundException.class)
             .hasMessage("file2 not found in target/test/ZipArchiveReadFileTest/test.zip");
     }
 
     @Test
+    @SuppressWarnings("resource") // for assertThatThrownBy
     public void should_throw_when_reading_file_not_in_archive() throws Exception {
         ZipArchive zipArchive = new ZipArchive(zipFile);
 
@@ -67,7 +70,7 @@ public class ZipArchiveReadFileTest extends AbstractTestWithTestDir {
         assertThat(zipArchive.isArchived()).isTrue();
 
         // Read the content of a file that is not in the archive
-        assertThatThrownBy(() -> zipArchive.readFile("path/to/file2").readAllBytes())
+        assertThatThrownBy(() -> zipArchive.readFile("path/to/file2"))
             .isInstanceOf(FileNotFoundException.class)
             .hasMessage("path/to/file2 not found in target/test/ZipArchiveReadFileTest/test.zip");
     }

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveReadFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveReadFileTest.java
@@ -17,7 +17,7 @@ package nl.knaw.dans.layerstore;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -50,7 +50,7 @@ public class ZipArchiveReadFileTest extends AbstractTestWithTestDir {
         }
         // getEntries in readFile returns only an exact match of the full path
         assertThatThrownBy(() -> zipArchive.readFile("file2"))
-            .isInstanceOf(FileNotFoundException.class)
+            .isInstanceOf(IOException.class)
             .hasMessage("file2 not found in target/test/ZipArchiveReadFileTest/test.zip");
     }
 
@@ -71,7 +71,7 @@ public class ZipArchiveReadFileTest extends AbstractTestWithTestDir {
 
         // Read the content of a file that is not in the archive
         assertThatThrownBy(() -> zipArchive.readFile("path/to/file2"))
-            .isInstanceOf(FileNotFoundException.class)
+            .isInstanceOf(IOException.class)
             .hasMessage("path/to/file2 not found in target/test/ZipArchiveReadFileTest/test.zip");
     }
 }

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveReadFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveReadFileTest.java
@@ -15,5 +15,41 @@
  */
 package nl.knaw.dans.layerstore;
 
-public class ZipArchiveReadFileTest {
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ZipArchiveReadFileTest extends AbstractTestWithTestDir {
+    Path zipFile = testDir.resolve("test.zip");
+
+    @Test
+    public void should_return_true_when_file_exists_in_archive() throws Exception {
+        ZipArchive zipArchive = new ZipArchive(zipFile);
+
+        createFileWithContent("file1");
+        createFileWithContent("path/to/file2");
+        createFileWithContent("path/to/file3");
+
+        // Archive the files
+        zipArchive.archiveFrom(stagingDir);
+
+        // Check that the zip file exists
+        assertThat(zipFile).exists();
+        assertThat(zipArchive.isArchived()).isTrue();
+
+        // Check that the content is archived
+        assertThat(zipArchive.readFile("path/to/file2").readAllBytes())
+            .isEqualTo("file2 content".getBytes());
+    }
+
+    private void createFileWithContent(String name) throws IOException {
+        var file = stagingDir.resolve(name);
+        var content = file.getFileName() + " content";
+        FileUtils.forceMkdir(file.getParent().toFile());
+        FileUtils.write(file.toFile(), content, "UTF-8");
+    }
 }

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveReadFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveReadFileTest.java
@@ -27,9 +27,8 @@ public class ZipArchiveReadFileTest extends AbstractTestWithTestDir {
     Path zipFile = testDir.resolve("test.zip");
 
     @Test
-    @SuppressWarnings("resource") // for assertThatThrownBy
     public void should_return_content_of_file_in_archive() throws Exception {
-        ZipArchive zipArchive = new ZipArchive(zipFile);
+        ZipArchive archive = new ZipArchive(zipFile);
 
         createStagingFileWithContent("file1");
         createStagingFileWithContent("path/to/file2");
@@ -37,40 +36,36 @@ public class ZipArchiveReadFileTest extends AbstractTestWithTestDir {
         createStagingFileWithContent("another/path/to/file2");
 
         // Archive the files
-        zipArchive.archiveFrom(stagingDir);
+        archive.archiveFrom(stagingDir);
 
         // Check that the zip file exists
         assertThat(zipFile).exists();
-        assertThat(zipArchive.isArchived()).isTrue();
+        assertThat(archive.isArchived()).isTrue();
 
         // Read the content of a file in the archive
-        try (var inputStream = zipArchive.readFile("path/to/file2")) {
+        try (var inputStream = archive.readFile("path/to/file2")) {
             assertThat(inputStream.readAllBytes())
                 .isEqualTo("path/to/file2 content".getBytes());
         }
-        // getEntries in readFile returns only an exact match of the full path
-        assertThatThrownBy(() -> zipArchive.readFile("file2"))
-            .isInstanceOf(IOException.class)
-            .hasMessage("file2 not found in target/test/ZipArchiveReadFileTest/test.zip");
     }
 
     @Test
     @SuppressWarnings("resource") // for assertThatThrownBy
     public void should_throw_when_reading_file_not_in_archive() throws Exception {
-        ZipArchive zipArchive = new ZipArchive(zipFile);
+        ZipArchive archive = new ZipArchive(zipFile);
 
         createStagingFileWithContent("file1");
         createStagingFileWithContent("path/to/file3");
 
         // Archive the files
-        zipArchive.archiveFrom(stagingDir);
+        archive.archiveFrom(stagingDir);
 
         // Check that the zip file exists
         assertThat(zipFile).exists();
-        assertThat(zipArchive.isArchived()).isTrue();
+        assertThat(archive.isArchived()).isTrue();
 
         // Read the content of a file that is not in the archive
-        assertThatThrownBy(() -> zipArchive.readFile("path/to/file2"))
+        assertThatThrownBy(() -> archive.readFile("path/to/file2"))
             .isInstanceOf(IOException.class)
             .hasMessage("path/to/file2 not found in target/test/ZipArchiveReadFileTest/test.zip");
     }

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveReadFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveReadFileTest.java
@@ -30,10 +30,10 @@ public class ZipArchiveReadFileTest extends AbstractTestWithTestDir {
     public void should_return_content_of_file_in_archive() throws Exception {
         ZipArchive archive = new ZipArchive(zipFile);
 
-        createStagingFileWithContent("file1");
-        createStagingFileWithContent("path/to/file2");
-        createStagingFileWithContent("path/to/file3");
-        createStagingFileWithContent("another/path/to/file2");
+        createStagingFileWithContent("file1", "file1 content");
+        createStagingFileWithContent("path/to/file2", "path/to/file2 content");
+        createStagingFileWithContent("path/to/file3", "path/to/file3 content");
+        createStagingFileWithContent("another/path/to/file2", "another/path/to/file2 content");
 
         // Archive the files
         archive.archiveFrom(stagingDir);
@@ -54,8 +54,8 @@ public class ZipArchiveReadFileTest extends AbstractTestWithTestDir {
     public void should_throw_when_reading_file_not_in_archive() throws Exception {
         ZipArchive archive = new ZipArchive(zipFile);
 
-        createStagingFileWithContent("file1");
-        createStagingFileWithContent("path/to/file3");
+        createStagingFileWithContent("file1", "file1 content");
+        createStagingFileWithContent("path/to/file3", "path/to/file3 content");
 
         // Archive the files
         archive.archiveFrom(stagingDir);

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveUnarchiveToTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveUnarchiveToTest.java
@@ -18,8 +18,8 @@ package nl.knaw.dans.layerstore;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 
 import static nl.knaw.dans.layerstore.TestUtils.assumeNotYetFixed;
@@ -78,8 +78,8 @@ public class ZipArchiveUnarchiveToTest extends AbstractTestWithTestDir {
         assertThatThrownBy(() -> zipArchive.unarchiveTo(testDir.resolve("unarchived")))
             .isInstanceOf(RuntimeException.class)
             .hasMessage("Could not unarchive target/test/ZipArchiveUnarchiveToTest/non-existing.zip")
-            .hasCauseInstanceOf(IOException.class)
-            .hasRootCauseMessage("target/test/ZipArchiveUnarchiveToTest/non-existing.zip (No such file or directory)");
+            .hasCauseInstanceOf(NoSuchFileException.class)
+            .hasRootCauseMessage("target/test/ZipArchiveUnarchiveToTest/non-existing.zip");
     }
 
     @Test

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveUnarchiveToTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveUnarchiveToTest.java
@@ -35,22 +35,22 @@ public class ZipArchiveUnarchiveToTest extends AbstractTestWithTestDir {
     @Test
     public void should_unarchive_zipfile() throws Exception {
         var zipFile = testDir.resolve("test.zip");
-        var zipArchive = new ZipArchive(zipFile);
+        var archive = new ZipArchive(zipFile);
 
         createStagingFileWithContent("file1", "file1 content");
         createStagingFileWithContent("path/to/file2", "path/to/file2 content");
         createStagingFileWithContent("path/to/file3", "path/to/file3 content");
 
         // Archive the files
-        zipArchive.archiveFrom(stagingDir);
+        archive.archiveFrom(stagingDir);
 
         // Check that the zip file exists
         assertThat(zipFile).exists();
-        assertThat(zipArchive.isArchived()).isTrue();
+        assertThat(archive.isArchived()).isTrue();
 
         // Unarchive the files
         var unarchived = testDir.resolve("unarchived");
-        zipArchive.unarchiveTo(unarchived);
+        archive.unarchiveTo(unarchived);
 
         // Check that the files are unarchived
         assertThat(unarchived.resolve("file1")).exists();
@@ -61,16 +61,16 @@ public class ZipArchiveUnarchiveToTest extends AbstractTestWithTestDir {
     @Test
     public void should_unarchive_zipfile_with_empty_directory() throws Exception {
         var zipFile = testDir.resolve("test.zip");
-        var zipArchive = new ZipArchive(zipFile);
+        var archive = new ZipArchive(zipFile);
         // Create an empty directory to archive
         Path emptyDir = stagingDir.resolve("emptyDir");
         FileUtils.forceMkdir(emptyDir.toFile());
 
         // Archive the empty directory
-        zipArchive.archiveFrom(stagingDir);
+        archive.archiveFrom(stagingDir);
 
         // Unarchive the files
-        zipArchive.unarchiveTo(testDir.resolve("unarchived"));
+        archive.unarchiveTo(testDir.resolve("unarchived"));
         assertThat(emptyDir).exists();
     }
 
@@ -107,10 +107,10 @@ public class ZipArchiveUnarchiveToTest extends AbstractTestWithTestDir {
     @Test
     public void should_throw_exception_when_unarchiving_non_existing_zipfile() {
         var zipFile = testDir.resolve("non-existing.zip");
-        var zipArchive = new ZipArchive(zipFile);
+        var archive = new ZipArchive(zipFile);
         assertThat(zipFile).doesNotExist();
-        assertThat(zipArchive.isArchived()).isFalse();
-        assertThatThrownBy(() -> zipArchive.unarchiveTo(testDir.resolve("unarchived")))
+        assertThat(archive.isArchived()).isFalse();
+        assertThatThrownBy(() -> archive.unarchiveTo(testDir.resolve("unarchived")))
             .isInstanceOf(RuntimeException.class)
             .hasMessage("Could not unarchive target/test/ZipArchiveUnarchiveToTest/non-existing.zip")
             .hasCauseInstanceOf(NoSuchFileException.class)
@@ -120,16 +120,16 @@ public class ZipArchiveUnarchiveToTest extends AbstractTestWithTestDir {
     @Test
     public void should_throw_exception_when_unarchiving_to_non_empty_directory() throws Exception {
         var zipFile = testDir.resolve("test.zip");
-        var zipArchive = new ZipArchive(zipFile);
+        var archive = new ZipArchive(zipFile);
 
         // Create a file to archive
         Files.createDirectories(stagingDir);
         Files.writeString(stagingDir.resolve("file1"), "file1 content");
-        zipArchive.archiveFrom(stagingDir);
+        archive.archiveFrom(stagingDir);
 
         Files.createDirectories(testDir.resolve("unarchived/content"));
 
         assumeNotYetFixed("unarchiveTo does not check if the target directory exists");
-        assertThatThrownBy(() -> zipArchive.unarchiveTo(testDir.resolve("unarchived")));
+        assertThatThrownBy(() -> archive.unarchiveTo(testDir.resolve("unarchived")));
     }
 }

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveUnarchiveToTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveUnarchiveToTest.java
@@ -37,9 +37,9 @@ public class ZipArchiveUnarchiveToTest extends AbstractTestWithTestDir {
         var zipFile = testDir.resolve("test.zip");
         var zipArchive = new ZipArchive(zipFile);
 
-        createStagingFileWithContent("file1");
-        createStagingFileWithContent("path/to/file2");
-        createStagingFileWithContent("path/to/file3");
+        createStagingFileWithContent("file1", "file1 content");
+        createStagingFileWithContent("path/to/file2", "path/to/file2 content");
+        createStagingFileWithContent("path/to/file3", "path/to/file3 content");
 
         // Archive the files
         zipArchive.archiveFrom(stagingDir);
@@ -63,9 +63,8 @@ public class ZipArchiveUnarchiveToTest extends AbstractTestWithTestDir {
         var zipFile = testDir.resolve("test.zip");
         var zipArchive = new ZipArchive(zipFile);
         // Create an empty directory to archive
-        Path emptyDir = testDir.resolve("staging/emptyDir");
+        Path emptyDir = stagingDir.resolve("emptyDir");
         FileUtils.forceMkdir(emptyDir.toFile());
-        FileUtils.forceMkdir(stagingDir.toFile());
 
         // Archive the empty directory
         zipArchive.archiveFrom(stagingDir);
@@ -79,12 +78,8 @@ public class ZipArchiveUnarchiveToTest extends AbstractTestWithTestDir {
     public void should_report_zip_slip() throws Exception {
         var zipFile = testDir.resolve("test.tar");
         var archive = new ZipArchive(zipFile);
-        // Create some files to archive
-        var file1 = stagingDir.resolve("file1");
 
-        // Write some string content to the files
-        FileUtils.write(file1.toFile(), "file1 content", "UTF-8");
-        Files.createDirectories(testDir.resolve("layer_staging"));
+        createStagingFileWithContent("file1", "file1 content");
 
         // Archive the files
         archive.archiveFrom(stagingDir);
@@ -126,7 +121,8 @@ public class ZipArchiveUnarchiveToTest extends AbstractTestWithTestDir {
     public void should_throw_exception_when_unarchiving_to_non_empty_directory() throws Exception {
         var zipFile = testDir.resolve("test.zip");
         var zipArchive = new ZipArchive(zipFile);
-        // Create a files to archive
+
+        // Create a file to archive
         Files.createDirectories(stagingDir);
         Files.writeString(stagingDir.resolve("file1"), "file1 content");
         zipArchive.archiveFrom(stagingDir);

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveUnarchiveToTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveUnarchiveToTest.java
@@ -33,9 +33,9 @@ public class ZipArchiveUnarchiveToTest extends AbstractTestWithTestDir {
         var zipFile = testDir.resolve("test.zip");
         var zipArchive = new ZipArchive(zipFile);
 
-        createFileWithContent("file1");
-        createFileWithContent("path/to/file2");
-        createFileWithContent("path/to/file3");
+        createStagingFileWithContent("file1");
+        createStagingFileWithContent("path/to/file2");
+        createStagingFileWithContent("path/to/file3");
 
         // Archive the files
         zipArchive.archiveFrom(stagingDir);
@@ -78,7 +78,7 @@ public class ZipArchiveUnarchiveToTest extends AbstractTestWithTestDir {
         assertThat(zipArchive.isArchived()).isFalse();
         assertThatThrownBy(() -> zipArchive.unarchiveTo(testDir.resolve("unarchived")))
             .isInstanceOf(RuntimeException.class)
-            .hasMessage("Could not unarchive zip file")
+            .hasMessage("Could not unarchive target/test/ZipArchiveUnarchiveToTest/non-existing.zip")
             .hasCauseInstanceOf(IOException.class)
             .hasRootCauseMessage("target/test/ZipArchiveUnarchiveToTest/non-existing.zip (No such file or directory)");
     }
@@ -96,12 +96,5 @@ public class ZipArchiveUnarchiveToTest extends AbstractTestWithTestDir {
 
         assumeNotYetFixed("unarchiveTo does not check if the target directory exists");
         assertThatThrownBy(() -> zipArchive.unarchiveTo(testDir.resolve("unarchived")));
-    }
-
-    private void createFileWithContent(String name) throws IOException {
-        var file = stagingDir.resolve(name);
-        var content = file.getFileName() + " content";
-        FileUtils.forceMkdir(file.getParent().toFile());
-        FileUtils.write(file.toFile(), content, "UTF-8");
     }
 }

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveUnarchiveToTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveUnarchiveToTest.java
@@ -32,19 +32,10 @@ public class ZipArchiveUnarchiveToTest extends AbstractTestWithTestDir {
     public void should_unarchive_zipfile() throws Exception {
         var zipFile = testDir.resolve("test.zip");
         var zipArchive = new ZipArchive(zipFile);
-        // Create some files to archive
-        var file1 = testDir.resolve("staging/file1");
-        var file2 = testDir.resolve("staging/path/to/file2");
-        var file3 = testDir.resolve("staging/path/to/file3");
 
-        // Write some string content to the files
-        var file1Content = "file1 content";
-        var file2Content = "file2 content";
-        var file3Content = "file3 content";
-        FileUtils.forceMkdir(file2.getParent().toFile());
-        FileUtils.write(file1.toFile(), file1Content, "UTF-8");
-        FileUtils.write(file2.toFile(), file2Content, "UTF-8");
-        FileUtils.write(file3.toFile(), file3Content, "UTF-8");
+        createFileWithContent("file1");
+        createFileWithContent("path/to/file2");
+        createFileWithContent("path/to/file3");
 
         // Archive the files
         zipArchive.archiveFrom(stagingDir);
@@ -54,12 +45,13 @@ public class ZipArchiveUnarchiveToTest extends AbstractTestWithTestDir {
         AssertionsForClassTypes.assertThat(zipArchive.isArchived()).isTrue();
 
         // Unarchive the files
-        zipArchive.unarchiveTo(testDir.resolve("unarchived"));
+        var unarchived = testDir.resolve("unarchived");
+        zipArchive.unarchiveTo(unarchived);
 
         // Check that the files are unarchived
-        assertThat(file1).exists();
-        assertThat(file2).exists();
-        assertThat(file3).exists();
+        assertThat(unarchived.resolve("file1")).exists();
+        assertThat(unarchived.resolve("path/to/file2")).exists();
+        assertThat(unarchived.resolve("path/to/file3")).exists();
     }
 
     @Test
@@ -104,5 +96,12 @@ public class ZipArchiveUnarchiveToTest extends AbstractTestWithTestDir {
 
         assumeNotYetFixed("unarchiveTo does not check if the target directory exists");
         assertThatThrownBy(() -> zipArchive.unarchiveTo(testDir.resolve("unarchived")));
+    }
+
+    private void createFileWithContent(String name) throws IOException {
+        var file = stagingDir.resolve(name);
+        var content = file.getFileName() + " content";
+        FileUtils.forceMkdir(file.getParent().toFile());
+        FileUtils.write(file.toFile(), content, "UTF-8");
     }
 }

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveUnarchiveToTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveUnarchiveToTest.java
@@ -127,9 +127,8 @@ public class ZipArchiveUnarchiveToTest extends AbstractTestWithTestDir {
         var zipFile = testDir.resolve("test.zip");
         var zipArchive = new ZipArchive(zipFile);
         // Create a files to archive
-        Files.createDirectories(testDir.resolve("staging"));
         Files.createDirectories(stagingDir);
-        Files.writeString(testDir.resolve("staging/file1"), "file1 content");
+        Files.writeString(stagingDir.resolve("file1"), "file1 content");
         zipArchive.archiveFrom(stagingDir);
 
         Files.createDirectories(testDir.resolve("unarchived/content"));

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveUnarchiveToTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveUnarchiveToTest.java
@@ -77,8 +77,8 @@ public class ZipArchiveUnarchiveToTest extends AbstractTestWithTestDir {
 
     @Test
     public void should_report_zip_slip() throws Exception {
-        var tarFile = testDir.resolve("test.tar");
-        var tarArchive = new ZipArchive(tarFile);
+        var zipFile = testDir.resolve("test.tar");
+        var archive = new ZipArchive(zipFile);
         // Create some files to archive
         var file1 = stagingDir.resolve("file1");
 
@@ -87,14 +87,14 @@ public class ZipArchiveUnarchiveToTest extends AbstractTestWithTestDir {
         Files.createDirectories(testDir.resolve("layer_staging"));
 
         // Archive the files
-        tarArchive.archiveFrom(stagingDir);
+        archive.archiveFrom(stagingDir);
 
-        // Check that the tar file exists
-        assertThat(tarFile).exists();
-        AssertionsForClassTypes.assertThat(tarArchive.isArchived()).isTrue();
+        // Check that the zip file exists
+        assertThat(zipFile).exists();
+        AssertionsForClassTypes.assertThat(archive.isArchived()).isTrue();
 
         // add malicious file to the archive
-        try (var zip = new ZipArchiveOutputStream(new FileOutputStream(tarFile.toFile()))) {
+        try (var zip = new ZipArchiveOutputStream(new FileOutputStream(zipFile.toFile()))) {
             var maliciousDir = testDir.resolve("violating/path");
             Files.createDirectories(maliciousDir);
             var entry = new ZipArchiveEntry(maliciousDir, "../" + maliciousDir);
@@ -104,10 +104,9 @@ public class ZipArchiveUnarchiveToTest extends AbstractTestWithTestDir {
 
         // Unarchive the files
         var unarchived = testDir.resolve("unarchived");
-        assertThatThrownBy(() -> tarArchive.unarchiveTo(unarchived))
+        assertThatThrownBy(() -> archive.unarchiveTo(unarchived))
             .hasCauseInstanceOf(IOException.class)
             .hasRootCauseMessage("Detected Zip Slip: ../target/test/ZipArchiveUnarchiveToTest/violating/path/ in target/test/ZipArchiveUnarchiveToTest/test.tar");
-        assertThat(unarchived).doesNotExist();
     }
 
     @Test

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveUnarchiveToTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveUnarchiveToTest.java
@@ -33,14 +33,14 @@ public class ZipArchiveUnarchiveToTest extends AbstractTestWithTestDir {
         var zipFile = testDir.resolve("test.zip");
         var zipArchive = new ZipArchive(zipFile);
         // Create some files to archive
-        Path file1 = testDir.resolve("staging/file1");
-        Path file2 = testDir.resolve("staging/path/to/file2");
-        Path file3 = testDir.resolve("staging/path/to/file3");
+        var file1 = testDir.resolve("staging/file1");
+        var file2 = testDir.resolve("staging/path/to/file2");
+        var file3 = testDir.resolve("staging/path/to/file3");
 
         // Write some string content to the files
-        String file1Content = "file1 content";
-        String file2Content = "file2 content";
-        String file3Content = "file3 content";
+        var file1Content = "file1 content";
+        var file2Content = "file2 content";
+        var file3Content = "file3 content";
         FileUtils.forceMkdir(file2.getParent().toFile());
         FileUtils.write(file1.toFile(), file1Content, "UTF-8");
         FileUtils.write(file2.toFile(), file2Content, "UTF-8");

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveUnarchiveToTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveUnarchiveToTest.java
@@ -16,7 +16,6 @@
 package nl.knaw.dans.layerstore;
 
 import org.apache.commons.io.FileUtils;
-import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -42,7 +41,7 @@ public class ZipArchiveUnarchiveToTest extends AbstractTestWithTestDir {
 
         // Check that the zip file exists
         assertThat(zipFile).exists();
-        AssertionsForClassTypes.assertThat(zipArchive.isArchived()).isTrue();
+        assertThat(zipArchive.isArchived()).isTrue();
 
         // Unarchive the files
         var unarchived = testDir.resolve("unarchived");

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveUnarchiveToTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveUnarchiveToTest.java
@@ -60,6 +60,7 @@ public class ZipArchiveUnarchiveToTest extends AbstractTestWithTestDir {
         // Create an empty directory to archive
         Path emptyDir = testDir.resolve("staging/emptyDir");
         FileUtils.forceMkdir(emptyDir.toFile());
+        FileUtils.forceMkdir(stagingDir.toFile());
 
         // Archive the empty directory
         zipArchive.archiveFrom(stagingDir);
@@ -88,6 +89,7 @@ public class ZipArchiveUnarchiveToTest extends AbstractTestWithTestDir {
         var zipArchive = new ZipArchive(zipFile);
         // Create a files to archive
         Files.createDirectories(testDir.resolve("staging"));
+        Files.createDirectories(stagingDir);
         Files.writeString(testDir.resolve("staging/file1"), "file1 content");
         zipArchive.archiveFrom(stagingDir);
 


### PR DESCRIPTION
Fixes DD-

# Description of changes

Knit picked and refactored Zip/Tar-Archive classes and their tests

- FileExists used to always return true.
- fixed Zip Slip vulnerability
- Made some error messages more verbose.
- Replaced deprecated ZipFile constructor.
- ArchiveFrom stores directory entries in ZipFile but not in TarFile.
- Replaced recursion with listFiles for ZipArchive.ArchiveFrom with Files.walk as TarArchive used to do
- Lambdas don’t like checked exceptions. So replaced foreach with loops.
- ZipFile and TarFile return bounded streams for entries, so wrapping in an anonymous FilteredInputStream is enough to override close to also(!) the backed stream.

# Review hint

Compare ZipArchive and TarArchive: the look alike except for the different apache.commons API's


# Related PRs 
(Add links)
* 

# Notify
@DANS-KNAW/core-systems
