### PR TITLE
DD-2009 Consistency checks dd-data-vault

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ DESCRIPTION
 ### Layer store
 
 A layer store is a hierarchical storage of files in a layered way. A layer contains a subset of the files and folders in the store. A layer is identified by a
-unique Layer ID. This ID is a unix timestamp in milliseconds. The layer IDs determine the order in which the layers are stacked. The contents of a layer store
+unique Layer ID. This ID is a Unix timestamp in milliseconds. The layer IDs determine the order in which the layers are stacked. The contents of a layer store
 can be transformed to a regular directory structure by stacking the layers in the order of their IDs. The layer with the highest ID is the top layer. Files in
 newer layers override files with the same path in older layers.
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     </scm>
     <properties>
         <!-- Todo: move to parent -->
-        <dans-java-utils.version>2.2.0</dans-java-utils.version>
+        <dans-java-utils.version>2.2.1-SNAPSHOT</dans-java-utils.version>
     </properties>
     <dependencies>
         <dependency>
@@ -55,6 +55,16 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
             <version>1.26.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>4.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-exec</artifactId>
+            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,11 @@
             <artifactId>dropwizard-hibernate</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     </scm>
     <properties>
         <!-- Todo: move to parent -->
-        <dans-java-utils.version>2.2.1-SNAPSHOT</dans-java-utils.version>
+        <dans-java-utils.version>2.3.0</dans-java-utils.version>
     </properties>
     <dependencies>
         <dependency>

--- a/src/main/java/nl/knaw/dans/layerstore/AbstractRunner.java
+++ b/src/main/java/nl/knaw/dans/layerstore/AbstractRunner.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.layerstore;
+
+import java.nio.file.Path;
+import java.util.regex.Pattern;
+
+public abstract class AbstractRunner {
+    private static final Pattern USER_HOST_PATTERN = Pattern.compile("^[a-zA-Z0-9._-]+$");
+    private static final Pattern COMMAND_INJECTION_PATTERN = Pattern.compile("[\\s;|&`$<>]");
+
+    protected static String checkExecutableForSecurity(Path path) {
+        var absPath = path.toAbsolutePath().toString();
+        if (COMMAND_INJECTION_PATTERN.matcher(absPath).find()) {
+            throw new IllegalArgumentException("Invalid executable path: " + absPath);
+        }
+        return absPath;
+    }
+
+    protected static String checkUserOrHostNameForSecurity(String param) {
+        if (!USER_HOST_PATTERN.matcher(param).matches()) {
+            throw new IllegalArgumentException("Invalid username: " + param);
+        }
+        return param;
+    }
+
+    protected static String checkRemoteBaseDirForSecurity(String param) {
+        if (param.contains("..")) {
+            throw new IllegalArgumentException("Invalid remote base directory: " + param);
+        }
+        return param;
+    }
+}

--- a/src/main/java/nl/knaw/dans/layerstore/AbstractRunner.java
+++ b/src/main/java/nl/knaw/dans/layerstore/AbstractRunner.java
@@ -18,6 +18,9 @@ package nl.knaw.dans.layerstore;
 import java.nio.file.Path;
 import java.util.regex.Pattern;
 
+/**
+ * Base class for command runners.
+ */
 public abstract class AbstractRunner {
     private static final Pattern USER_HOST_PATTERN = Pattern.compile("^[a-zA-Z0-9._-]+$");
     private static final Pattern COMMAND_INJECTION_PATTERN = Pattern.compile("[\\s;|&`$<>]");

--- a/src/main/java/nl/knaw/dans/layerstore/Archive.java
+++ b/src/main/java/nl/knaw/dans/layerstore/Archive.java
@@ -18,6 +18,7 @@ package nl.knaw.dans.layerstore;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.util.Iterator;
 
 /**
  * An archive is a file that contains a collection of files and directories. It can be implemented as a zip file, a tar, etc.
@@ -34,8 +35,7 @@ public interface Archive {
     InputStream readFile(String filePath) throws IOException;
 
     /**
-     * Unarchives the archive to the given staging directory. Note that the {@link #isArchived()} will <em>not</em> return {@code false} after this operation,
-     * as the archive file is not removed.
+     * Unarchives the archive to the given staging directory. Note that the {@link #isArchived()} will <em>not</em> return {@code false} after this operation, as the archive file is not removed.
      *
      * @param stagingDir the directory to unarchive to
      */
@@ -49,6 +49,7 @@ public interface Archive {
     void archiveFrom(Path stagingDir);
 
     // TODO: is it possible that archived changes back to false? What this exact meaning of this attribute?
+
     /**
      * Returns whether the archive has been created.
      *
@@ -64,4 +65,10 @@ public interface Archive {
      */
     boolean fileExists(String filePath);
 
+    /**
+     * Lists all items in the archive. The paths of the items are relative to the root of the archive. The iterator includes the root of the archive itself as a directory item with an empty path.
+     *
+     * @return an iterator over all items in the archive
+     */
+    Iterator<Item> listAllItems() throws IOException;
 }

--- a/src/main/java/nl/knaw/dans/layerstore/ArchiveProvider.java
+++ b/src/main/java/nl/knaw/dans/layerstore/ArchiveProvider.java
@@ -15,24 +15,35 @@
  */
 package nl.knaw.dans.layerstore;
 
+import java.util.List;
+
 /**
  * Provides a way to create an Archive. The implementation should provide a way to configure where the archive is stored.
  */
 public interface ArchiveProvider {
 
     /**
-     * Create a new {@link Archive} instance.
+     * Create a new {@link Archive} instance for the given layer ID.
      *
-     * @param path the path to the archive file
+     * @param layerId the layer ID
      * @return the new archive
      */
-    Archive createArchive(String path);
+    Archive createArchive(long layerId);
+
 
     /**
      * Check if an archive exists at the given path.
      *
-     * @param path the path to the archive file
+     * @param layerId the layer ID
      * @return true if the archive exists, false otherwise
      */
-    boolean exists(String path);
+    boolean exists(long layerId);
+
+
+    /**
+     * List all archived layer IDs.
+     *
+     * @return a list of layer IDs for which archives exist
+     */
+    List<Long> listArchivedLayers();
 }

--- a/src/main/java/nl/knaw/dans/layerstore/ArchiveProvider.java
+++ b/src/main/java/nl/knaw/dans/layerstore/ArchiveProvider.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.layerstore;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -45,5 +46,5 @@ public interface ArchiveProvider {
      *
      * @return a list of layer IDs for which archives exist
      */
-    List<Long> listArchivedLayers();
+    List<Long> listArchivedLayers() throws IOException;
 }

--- a/src/main/java/nl/knaw/dans/layerstore/ConsistencyCheckingAsyncLayerArchiver.java
+++ b/src/main/java/nl/knaw/dans/layerstore/ConsistencyCheckingAsyncLayerArchiver.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.layerstore;
+
+import java.io.IOException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+/**
+ * An {@link LayerArchiver} that archives layers in a separate thread. It also checks that the items found on storage are the same as the items found in the database for the layer.
+ */
+public class ConsistencyCheckingAsyncLayerArchiver implements LayerArchiver {
+    private final LayeredItemStore itemStore;
+    private final Executor executor;
+
+    public ConsistencyCheckingAsyncLayerArchiver(LayeredItemStore itemStore) {
+        this(itemStore, null);
+    }
+
+    public ConsistencyCheckingAsyncLayerArchiver(LayeredItemStore itemStore, Executor executor) {
+        this.itemStore = itemStore;
+        this.executor = executor == null ? Executors.newSingleThreadExecutor() : executor;
+    }
+
+    @Override
+    public void archive(Layer layer) {
+        executor.execute(() -> {
+            try {
+                itemStore.checkSameItemsFoundOnStorageAsInDatabaseFor(layer.getId());
+                layer.archive();
+            }
+            catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+}

--- a/src/main/java/nl/knaw/dans/layerstore/DatabaseBackedContentManager.java
+++ b/src/main/java/nl/knaw/dans/layerstore/DatabaseBackedContentManager.java
@@ -23,7 +23,7 @@ public interface DatabaseBackedContentManager {
     /**
      * Test if the content at the given path should be stored in the database.
      *
-     * @param path the path of the content relative to the root of store
+     * @param path the path of the content relative to the root of the store
      * @return true if the content should be stored in the database, false otherwise
      */
     boolean test(String path);
@@ -34,7 +34,7 @@ public interface DatabaseBackedContentManager {
      * <p>
      * The most important use case for this method is to compress the content before it is stored in the database.
      *
-     * @param path  the path of the content relative to the root of store
+     * @param path  the path of the content relative to the root of the store
      * @param bytes the content to be stored
      * @return the processed content
      */
@@ -46,7 +46,7 @@ public interface DatabaseBackedContentManager {
      * <p>
      * The most important use case for this method is to decompress the content after it is retrieved from the database (assuming it was compressed before it was stored).
      *
-     * @param path  the path of the content relative to the root of store
+     * @param path  the path of the content relative to the root of the store
      * @param bytes the content to be processed
      * @return the processed content
      */

--- a/src/main/java/nl/knaw/dans/layerstore/DirectLayerArchiver.java
+++ b/src/main/java/nl/knaw/dans/layerstore/DirectLayerArchiver.java
@@ -15,21 +15,13 @@
  */
 package nl.knaw.dans.layerstore;
 
-import lombok.Builder;
-import lombok.Data;
-
 /**
- * A file or directory in the layer store. It may be represented by multiple ItemRecords in the database, one for each layer that contains the item. Note that to obtain the current (i.e., latest)
- * content of a File item, you need to retrieve the ItemRecord with the highest layerId.
+ * A {@link LayerArchiver} that archives layers directly, not performing any consistency checks nor scheduling archiving.
  */
-@Data
-@Builder
-public class Item {
-    public enum Type {
-        File,
-        Directory
-    }
+public class DirectLayerArchiver implements LayerArchiver {
 
-    private final String path;
-    private final Type type;
+    @Override
+    public void archive(Layer layer) {
+        layer.archive();
+    }
 }

--- a/src/main/java/nl/knaw/dans/layerstore/DirectoryTreeItemIterator.java
+++ b/src/main/java/nl/knaw/dans/layerstore/DirectoryTreeItemIterator.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.layerstore;
+
+import nl.knaw.dans.layerstore.Item.Type;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.TrueFileFilter;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Iterator;
+
+/**
+ * An iterator that traverses a directory tree and yields {@link Item}s representing files and directories. The paths of the items are relative to the provided root directory. The iterator includes
+ * the root directory itself as an item with an empty path.
+ */
+public class DirectoryTreeItemIterator implements Iterator<Item> {
+    private final Path directoryPath;
+    private final Iterator<File> pathIterator;
+
+    public DirectoryTreeItemIterator(Path directoryPath) throws IOException {
+        this.directoryPath = directoryPath;
+        this.pathIterator = FileUtils.iterateFilesAndDirs(directoryPath.toFile(), TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE);
+    }
+
+    public boolean hasNext() {
+        return pathIterator.hasNext();
+    }
+
+    @Override
+    public Item next() {
+        var next = pathIterator.next();
+        return new Item(directoryPath.relativize(next.toPath()).toString(),
+            next.isDirectory() ? Type.Directory : Type.File);
+    }
+}

--- a/src/main/java/nl/knaw/dans/layerstore/DmfTarArchive.java
+++ b/src/main/java/nl/knaw/dans/layerstore/DmfTarArchive.java
@@ -30,7 +30,7 @@ public class DmfTarArchive implements Archive {
     private final String path;
 
     @Getter
-    private boolean archived;
+    private final boolean archived;
 
     public DmfTarArchive(@NonNull DmfTarRunner dmfTarRunner, @NonNull String path, boolean archived) {
         this.dmfTarRunner = dmfTarRunner;

--- a/src/main/java/nl/knaw/dans/layerstore/DmfTarArchive.java
+++ b/src/main/java/nl/knaw/dans/layerstore/DmfTarArchive.java
@@ -61,7 +61,6 @@ public class DmfTarArchive implements Archive {
 
     @Override
     public Iterator<Item> listAllItems() {
-        return null;
+        return new DmfTarArchiveItemIterator(path, dmfTarRunner);
     }
-
 }

--- a/src/main/java/nl/knaw/dans/layerstore/DmfTarArchive.java
+++ b/src/main/java/nl/knaw/dans/layerstore/DmfTarArchive.java
@@ -22,6 +22,7 @@ import lombok.SneakyThrows;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.util.Iterator;
 
 public class DmfTarArchive implements Archive {
     private final DmfTarRunner dmfTarRunner;
@@ -56,6 +57,11 @@ public class DmfTarArchive implements Archive {
     @SneakyThrows
     public boolean fileExists(String filePath) {
         return dmfTarRunner.fileExists(path, "./" + filePath);
+    }
+
+    @Override
+    public Iterator<Item> listAllItems() {
+        return null;
     }
 
 }

--- a/src/main/java/nl/knaw/dans/layerstore/DmfTarArchiveItemIterator.java
+++ b/src/main/java/nl/knaw/dans/layerstore/DmfTarArchiveItemIterator.java
@@ -1,0 +1,47 @@
+package nl.knaw.dans.layerstore;
+
+import java.util.Iterator;
+
+public class DmfTarArchiveItemIterator implements Iterator<Item> {
+    /**
+     * The root item represents the root of the zip archive, and is implicitly present in every zip archive.
+     */
+    private final Item rootItem = new Item("", Item.Type.Directory);
+
+    private boolean rootReturned = false;
+
+    private final Iterator<String> entries;
+
+    /**
+     * Creates a new iterator over the items in the given archive.
+     *
+     * @param archiveName  the name of the archive to iterate over (without path)
+     * @param dmfTarRunner the DmfTarRunner to use for accessing the archive
+     */
+    public DmfTarArchiveItemIterator(String archiveName, DmfTarRunner dmfTarRunner) {
+        this.entries = dmfTarRunner.listFiles(archiveName);
+    }
+
+    @Override
+    public boolean hasNext() {
+        if (!rootReturned) {
+            return true;
+        }
+        return entries.hasNext();
+    }
+
+    @Override
+    public Item next() {
+        if (!rootReturned) {
+            rootReturned = true;
+            return rootItem;
+        }
+        var next = entries.next();
+        // Remove trailing slash from directory names
+        var name = next;
+        if (name.endsWith("/")) {
+            name = name.substring(0, name.length() - 1);
+        }
+        return new Item(name, next.endsWith("/") ? Item.Type.Directory : Item.Type.File);
+    }
+}

--- a/src/main/java/nl/knaw/dans/layerstore/DmfTarArchiveProvider.java
+++ b/src/main/java/nl/knaw/dans/layerstore/DmfTarArchiveProvider.java
@@ -17,18 +17,30 @@ package nl.knaw.dans.layerstore;
 
 import lombok.AllArgsConstructor;
 
+import java.util.List;
+
 @AllArgsConstructor
 public class DmfTarArchiveProvider implements ArchiveProvider {
     private final DmfTarRunner dmfTarRunner;
     private final SshRunner sshRunner;
 
     @Override
-    public Archive createArchive(String path) {
-        return new DmfTarArchive(dmfTarRunner, path + ".dmftar", exists(path));
+    public Archive createArchive(long layerId) {
+        return new DmfTarArchive(dmfTarRunner, layerId + ".dmftar", exists(layerId));
     }
 
     @Override
-    public boolean exists(String path) {
-        return sshRunner.fileExists(path + ".dmftar");
+    public boolean exists(long layerId) {
+        return sshRunner.fileExists(layerId + ".dmftar");
     }
+
+    @Override
+    public List<Long> listArchivedLayers() {
+        return sshRunner.listFiles().stream()
+            .filter(name -> name.endsWith(".dmftar"))
+            .map(name -> name.substring(0, name.length() - ".dmftar".length()))
+            .map(Long::valueOf)
+            .toList();
+    }
+
 }

--- a/src/main/java/nl/knaw/dans/layerstore/DmfTarArchiveProvider.java
+++ b/src/main/java/nl/knaw/dans/layerstore/DmfTarArchiveProvider.java
@@ -17,6 +17,7 @@ package nl.knaw.dans.layerstore;
 
 import lombok.AllArgsConstructor;
 
+import java.io.IOException;
 import java.util.List;
 
 @AllArgsConstructor
@@ -35,7 +36,7 @@ public class DmfTarArchiveProvider implements ArchiveProvider {
     }
 
     @Override
-    public List<Long> listArchivedLayers() {
+    public List<Long> listArchivedLayers() throws IOException {
         return sshRunner.listFiles().stream()
             .filter(name -> name.endsWith(".dmftar"))
             .map(name -> name.substring(0, name.length() - ".dmftar".length()))

--- a/src/main/java/nl/knaw/dans/layerstore/DmfTarRunner.java
+++ b/src/main/java/nl/knaw/dans/layerstore/DmfTarRunner.java
@@ -15,78 +15,189 @@
  */
 package nl.knaw.dans.layerstore;
 
-import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import nl.knaw.dans.lib.util.ProcessInputStream;
-import nl.knaw.dans.lib.util.ProcessRunner;
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.DefaultExecutor;
+import org.apache.commons.exec.ExecuteException;
+import org.apache.commons.exec.ExecuteResultHandler;
+import org.apache.commons.exec.PumpStreamHandler;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.LineIterator;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Iterator;
-import java.util.stream.Stream;
+import java.util.regex.Pattern;
 
-@AllArgsConstructor
+/**
+ * A runner for the dmftar command line tool, which creates and reads DMF TAR archives on a remote host via SSH.
+ * <p>
+ * Security: all parameters provided to the constructor are validated to prevent command injection attacks. The {@link #tarDirectory(Path, String)} method checks that the directory to be archived does
+ * not contain any subdirectories prefixed with 'dmftar-cache.', as these may conflict with temporary cache directories created by dmftar itself.
+ */
 @Slf4j
 public class DmfTarRunner {
+    private static final Pattern USER_HOST_PATTERN = Pattern.compile("^[a-zA-Z0-9._-]+$");
+    private static final Pattern COMMAND_INJECTION_PATTERN = Pattern.compile("[\\s;|&`$<>]");
     private final Path dmfTarExecutable;
+
     private final String user;
     private final String host;
     private final Path remoteBaseDir;
 
+    /**
+     * Creates a new DmfTarRunner.
+     *
+     * @param dmfTarExecutable path to the dmftar executable
+     * @param user             username for the remote host
+     * @param host             host name or IP address of the remote host
+     * @param remoteBaseDir    base directory on the remote host where archives are stored
+     */
+    public DmfTarRunner(Path dmfTarExecutable, String user, String host, Path remoteBaseDir) {
+        this.dmfTarExecutable = Path.of(checkExecutableForSecurity(dmfTarExecutable));
+        this.user = checkUserOrHostNameForSecurity(user);
+        this.host = checkUserOrHostNameForSecurity(host);
+        this.remoteBaseDir = Path.of(checkRemoteBaseDirForSecurity(remoteBaseDir.toString()));
+    }
+
+    /**
+     * Create DMF TAR archive from the contents of the given directory. The directory itself is not included in the archive. The directory must not contain any subdirectories prefixed with
+     * 'dmftar-cache.', as these may conflict with temporary cache directories created by dmftar itself. The resulting DMT TAR archive will be created in the remote base directory with the given
+     * name.
+     *
+     * @param directory   the directory to archive
+     * @param archiveName the name of the archive to create on the remote host
+     */
     public void tarDirectory(Path directory, String archiveName) {
+        checkForDmftarCacheDirectories(directory);
         var commandLine = CommandLine.parse(dmfTarExecutable.toAbsolutePath() + " -cf " + getRemotePath(archiveName) + " .");
         var executor = DefaultExecutor.builder()
             .setWorkingDirectory(directory.toAbsolutePath().toFile())
             .get();
         try {
             executor.execute(commandLine);
-        } catch (IOException e) {
+        }
+        catch (IOException e) {
             throw new RuntimeException("Failed to create tar archive: " + e.getMessage(), e);
         }
     }
 
-    public InputStream readFile(String archiveName, String fileName) {
-        var runner = new ProcessRunner(dmfTarExecutable.toAbsolutePath().toString(),
-            "-o=-O", // Send extra option to underlying tar command to write to stdout
-            "-q", // Suppress dmftar messages to stdout
-            "-xf", // Extract files from archive
-            getRemotePath(archiveName), fileName);
-        return new ProcessInputStream(runner.start());
+    private void checkForDmftarCacheDirectories(Path directory) {
+        var cacheDirs = directory.toFile().listFiles((file) -> file.isDirectory() && file.getName().startsWith("dmftar-cache."));
+        if (cacheDirs != null && cacheDirs.length > 0) {
+            throw new IllegalArgumentException("Directory to be archived contains directories prefixed with 'dmftar-cache.': " + cacheDirs[0].getAbsolutePath());
+        }
     }
 
+    /**
+     * Reads a file from a DMF TAR archive on the remote host.contents
+     *
+     * @param archiveName the name of the archive to read from
+     * @param fileName    the name of the file to read from the archive
+     * @return an InputStream for reading the file
+     */
+    public InputStream readFile(String archiveName, String fileName) {
+        var commandLine = new CommandLine(dmfTarExecutable.toAbsolutePath().toString())
+            .addArgument("-xfO")
+            .addArgument(getRemotePath(archiveName))
+            .addArgument(fileName);
+        try {
+            return getInputStreamFor(commandLine);
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Failed to read file from archive: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Lists the files in a DMF TAR archive on the remote host.
+     *
+     * @param archiveName the name of the archive to list files from
+     * @return an Iterator over the file names in the archive
+     */
+    public Iterator<String> listFiles(String archiveName) {
+        var commandLine = new CommandLine(dmfTarExecutable.toAbsolutePath().toString())
+            .addArgument("-qtf")
+            .addArgument(getRemotePath(archiveName));
+        try {
+            var inputStream = getInputStreamFor(commandLine);
+            var reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+            return new LineIterator(reader);
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Failed to list files in archive: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Checks if a file exists in a DMF TAR archive on the remote host.
+     *
+     * @param archiveName the name of the archive to check
+     * @param fileName    the name of the file to check for
+     * @return true if the file exists in the archive, false otherwise
+     * @throws IOException if an I/O error occurs
+     */
     public boolean fileExists(String archiveName, String fileName) throws IOException {
-        var runner = new ProcessRunner(dmfTarExecutable.toAbsolutePath().toString(),
-            "-tf", // List files in archive
-            "-q", // Suppress dmftar messages to stdout
-            getRemotePath(archiveName));
-        var reader = new BufferedReader(new InputStreamReader(new ProcessInputStream(runner.start()), StandardCharsets.UTF_8));
-        String line;
-        while ((line = reader.readLine()) != null) {
-            if (line.equals(fileName)) {
+        var it = listFiles(archiveName);
+        while (it.hasNext()) {
+            if (it.next().equals(fileName)) {
                 return true;
             }
         }
         return false;
     }
 
-    public Iterator<String> listFiles(String archiveName) {
-        var runner = new ProcessRunner(dmfTarExecutable.toAbsolutePath().toString(),
-            "-tf", // List files in archive
-            "-q", // Suppress dmftar messages to stdout
-            getRemotePath(archiveName));
-        var process = runner.start();
-        var reader = new BufferedReader(new InputStreamReader(new ProcessInputStream(process), StandardCharsets.UTF_8));
-        return new LineIterator(reader);
+    private InputStream getInputStreamFor(CommandLine commandLine) throws IOException {
+        var executor = DefaultExecutor.builder().get();
+        var outputStream = new PipedOutputStream();
+        var inputStream = new PipedInputStream(outputStream);
+        var streamHandler = new PumpStreamHandler(outputStream);
+        executor.setStreamHandler(streamHandler);
+        executor.execute(commandLine, new ExecuteResultHandler() {
+
+            @Override
+            public void onProcessComplete(int exitValue) {
+                IOUtils.closeQuietly(outputStream);
+            }
+
+            @Override
+            public void onProcessFailed(ExecuteException e) {
+                IOUtils.closeQuietly(outputStream);
+                log.error("Failed to execute command: " + e.getMessage(), e);
+            }
+        });
+        return inputStream;
     }
 
     private String getRemotePath(String archiveName) {
         return user + "@" + host + ":" + remoteBaseDir.resolve(archiveName);
+    }
+
+    private static String checkExecutableForSecurity(Path path) {
+        var absPath = path.toAbsolutePath().toString();
+        if (COMMAND_INJECTION_PATTERN.matcher(absPath).find()) {
+            throw new IllegalArgumentException("Invalid executable path: " + absPath);
+        }
+        return absPath;
+    }
+
+    private static String checkUserOrHostNameForSecurity(String param) {
+        if (!USER_HOST_PATTERN.matcher(param).matches()) {
+            throw new IllegalArgumentException("Invalid username: " + param);
+        }
+        return param;
+    }
+
+    private static String checkRemoteBaseDirForSecurity(String param) {
+        if (param.contains("..")) {
+            throw new IllegalArgumentException("Invalid remote base directory: " + param);
+        }
+        return param;
     }
 }

--- a/src/main/java/nl/knaw/dans/layerstore/DmfTarRunner.java
+++ b/src/main/java/nl/knaw/dans/layerstore/DmfTarRunner.java
@@ -67,7 +67,7 @@ public class DmfTarRunner {
     }
 
     /**
-     * Create DMF TAR archive from the contents of the given directory. The directory itself is not included in the archive. The directory must not contain any subdirectories prefixed with
+     * Create a DMF TAR archive from the contents of the given directory. The directory itself is not included in the archive. The directory must not contain any subdirectories prefixed with
      * 'dmftar-cache.', as these may conflict with temporary cache directories created by dmftar itself. The resulting DMT TAR archive will be created in the remote base directory with the given
      * name.
      *

--- a/src/main/java/nl/knaw/dans/layerstore/ItemStore.java
+++ b/src/main/java/nl/knaw/dans/layerstore/ItemStore.java
@@ -26,7 +26,7 @@ import java.util.List;
  * but other implementations are conceivable. The main reason for defining this interface in more general terms is to hide the details of the underlying storage mechanism from the client code.
  * </p>
  * <p>
- * An ItemStore has a storage root, which is implementation dependent.
+ * An ItemStore has a storage root, which is implementation-dependent.
  * </p>
  */
 public interface ItemStore {

--- a/src/main/java/nl/knaw/dans/layerstore/ItemStore.java
+++ b/src/main/java/nl/knaw/dans/layerstore/ItemStore.java
@@ -36,7 +36,7 @@ public interface ItemStore {
      * @param directoryPath the directory path relative to the storage root
      * @return the items in the directory
      * @throws java.nio.file.NoSuchFileException if the directory does not exist in any of the layers
-     * @throws java.nio.file.NotDirectoryException if the path exists, but is not a directory
+     * @throws java.nio.file.NotDirectoryException if the path exists but is not a directory
      */
     List<Item> listDirectory(String directoryPath) throws IOException;
 
@@ -46,7 +46,7 @@ public interface ItemStore {
      * @param directoryPath the directory path relative to the storage root
      * @return the items in the directory and its subdirectories
      * @throws java.nio.file.NoSuchFileException if the directory does not exist in any of the layers
-     * @throws java.nio.file.NotDirectoryException if the path exists, but is not a directory
+     * @throws java.nio.file.NotDirectoryException if the path exists but is not a directory
      */
     List<Item> listRecursive(String directoryPath) throws IOException;
 

--- a/src/main/java/nl/knaw/dans/layerstore/ItemsMatchDbConsistencyChecker.java
+++ b/src/main/java/nl/knaw/dans/layerstore/ItemsMatchDbConsistencyChecker.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.layerstore;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.IteratorUtils;
+
+import java.io.IOException;
+
+import static nl.knaw.dans.layerstore.Utils.throwOnListDifference;
+
+@Slf4j
+@AllArgsConstructor
+public class ItemsMatchDbConsistencyChecker implements LayerConsistencyChecker {
+    private final LayerDatabase database;
+
+    @Override
+    public void check(Layer layer) throws IOException {
+        checkSameItemsFoundOnStorageAsInDatabase(layer);
+    }
+
+    private void checkSameItemsFoundOnStorageAsInDatabase(Layer layer) throws IOException {
+        log.debug("Checking consistency of items found on storage for layer {}", layer.getId());
+        var itemsInDb = database.getRecordsByLayerId(layer.getId()).stream().map(ItemRecord::toItem).toList();
+        var itemsOnStorage = IteratorUtils.toList(layer.listAllItems());
+        throwOnListDifference(itemsInDb, itemsOnStorage, "Items found on storage do not match items in database.");
+        log.debug("Consistency check of items found on storage for layer {} passed.", layer.getId());
+    }
+}

--- a/src/main/java/nl/knaw/dans/layerstore/Layer.java
+++ b/src/main/java/nl/knaw/dans/layerstore/Layer.java
@@ -30,7 +30,7 @@ public interface Layer {
     long getId();
 
     /**
-     * Changes the state of the layer to closed.
+     * Changes the state of the layer to 'closed'.
      *
      * @throws IllegalStateException if the layer is already closed
      */

--- a/src/main/java/nl/knaw/dans/layerstore/Layer.java
+++ b/src/main/java/nl/knaw/dans/layerstore/Layer.java
@@ -21,6 +21,55 @@ import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
 
+/**
+ * This interface represents a layer in the layered item store. A layer can be in the following states:
+ *
+ * <table>
+ *   <thead>
+ *     <tr>
+ *       <th>#</th><th>open/closed</th><th>archived</th><th>staged?</th><th>when?</th>
+ *     </tr>
+ *   </thead>
+ *   <tbody>
+ *     <tr>
+ *       <td>1</td>
+ *       <td>open</td>
+ *       <td>niet archived</td>
+ *       <td>ja</td>
+ *       <td>beginsituatie van elke top layer</td>
+ *     </tr>
+ *     <tr>
+ *       <td>2</td>
+ *       <td>closed</td>
+ *       <td>niet archived</td>
+ *       <td>ja (met .closed suffix)</td>
+ *       <td>op het moment voordat de top layer gearchiveerd wordt</td>
+ *     </tr>
+ *     <tr>
+ *       <td>3</td>
+ *       <td>closed</td>
+ *       <td>archived</td>
+ *       <td>nee</td>
+ *       <td>archivering gelukt</td>
+ *     </tr>
+ *     <tr>
+ *       <td>4</td>
+ *       <td>open</td>
+ *       <td>archived</td>
+ *       <td>ja</td>
+ *       <td>reopened</td>
+ *     </tr>
+ *     <tr>
+ *       <td>5</td>
+ *       <td>closed</td>
+ *       <td>archived</td>
+ *       <td>ja (met .closed suffix)</td>
+ *       <td>close van een heropende layer</td>
+ *     </tr>
+ *   </tbody>
+ * </table>
+ *
+ */
 public interface Layer {
     /**
      * Returns the id of the layer.

--- a/src/main/java/nl/knaw/dans/layerstore/Layer.java
+++ b/src/main/java/nl/knaw/dans/layerstore/Layer.java
@@ -18,6 +18,7 @@ package nl.knaw.dans.layerstore;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.util.Iterator;
 import java.util.List;
 
 public interface Layer {
@@ -59,12 +60,38 @@ public interface Layer {
      */
     boolean isArchived();
 
+    /**
+     * Creates a directory at the given path. Not allowed when the layer is closed.
+     *
+     * @param path the path of the directory relative to the storage root
+     * @throws IOException if the directory cannot be created
+     */
     void createDirectory(String path) throws IOException;
 
+    /**
+     * Deletes the directory at the given path, including all its contents. Not allowed when the layer is closed.
+     *
+     * @param path the path of the directory relative to the storage root
+     * @throws IOException if the directory cannot be deleted
+     */
     void deleteDirectory(String path) throws IOException;
 
+    /**
+     * Returns whether a file exists at the given path in this layer.
+     *
+     * @param path the path of the file relative to the storage root
+     * @return whether the file exists
+     * @throws IOException if the existence of the file cannot be determined
+     */
     boolean fileExists(String path) throws IOException;
 
+    /**
+     * Reads the file at the given path. Note, that this may take a long time if the layer is archived, especially when the archive is stored on tape.
+     *
+     * @param path the path of the file relative to the storage root
+     * @return an input stream for reading the file; the caller is responsible for closing the stream
+     * @throws IOException if the file cannot be read
+     */
     InputStream readFile(String path) throws IOException;
 
     /**
@@ -84,9 +111,37 @@ public interface Layer {
      */
     void deleteFiles(List<String> paths) throws IOException;
 
+    /**
+     * Moves the directory at <code>source</code> into the directory at <code>destination</code>. Not allowed when the layer is closed.
+     *
+     * @param source      the path of the directory to be moved; must be an existing directory
+     * @param destination the path of the directory to move into; the directory is created if it does not exist yet
+     * @throws IOException if the directory cannot be moved
+     */
     void moveDirectoryInto(Path source, String destination) throws IOException;
 
+    /**
+     * Moves the directory at <code>source</code> to <code>destination</code>, where both paths are relative to the root of the layer.
+     *
+     * @param source      the path of the directory to be moved; must be an existing directory
+     * @param destination the path of the destination directory; must not exist yet
+     * @throws IOException if the directory cannot be moved
+     */
     void moveDirectoryInternal(String source, String destination) throws IOException;
 
+    /**
+     * Returns the size of the layer in bytes. If the layer is archived, this may take a long time, especially when the archive is stored on tape.
+     *
+     * @return the size of the layer in bytes
+     * @throws IOException if the size cannot be determined
+     */
     long getSizeInBytes() throws IOException;
+
+    /**
+     * Lists the items in this layer.
+     *
+     * @return the items in this layer
+     * @throws IOException if the items cannot be listed
+     */
+    Iterator<Item> listAllItems() throws IOException;
 }

--- a/src/main/java/nl/knaw/dans/layerstore/LayerArchiver.java
+++ b/src/main/java/nl/knaw/dans/layerstore/LayerArchiver.java
@@ -15,21 +15,10 @@
  */
 package nl.knaw.dans.layerstore;
 
-import lombok.Builder;
-import lombok.Data;
-
 /**
- * A file or directory in the layer store. It may be represented by multiple ItemRecords in the database, one for each layer that contains the item. Note that to obtain the current (i.e., latest)
- * content of a File item, you need to retrieve the ItemRecord with the highest layerId.
+ * Interface for archiving layers. This interface is used by the {@link LayerManager} to archive layers.
  */
-@Data
-@Builder
-public class Item {
-    public enum Type {
-        File,
-        Directory
-    }
+public interface LayerArchiver {
 
-    private final String path;
-    private final Type type;
+    void archive(Layer layer);
 }

--- a/src/main/java/nl/knaw/dans/layerstore/LayerConsistencyChecker.java
+++ b/src/main/java/nl/knaw/dans/layerstore/LayerConsistencyChecker.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.layerstore;
+
+import java.io.IOException;
+
+public interface LayerConsistencyChecker {
+
+    public void check(Layer layer) throws IOException;
+
+}

--- a/src/main/java/nl/knaw/dans/layerstore/LayerDatabase.java
+++ b/src/main/java/nl/knaw/dans/layerstore/LayerDatabase.java
@@ -94,4 +94,12 @@ public interface LayerDatabase {
      * @return true if the pattern matches any path in the database, false otherwise
      */
     boolean existsPathLike(String pathPattern);
+
+    /**
+     * Lists all layer IDs that are currently in the database.
+     *
+     * @return a list of layer IDs
+     */
+    List<Long> listLayerIds();
+
 }

--- a/src/main/java/nl/knaw/dans/layerstore/LayerDatabase.java
+++ b/src/main/java/nl/knaw/dans/layerstore/LayerDatabase.java
@@ -63,7 +63,7 @@ public interface LayerDatabase {
     List<Item> listRecursive(String directoryPath) throws IOException;
 
     /**
-     * Adds a directory to the database. Ancestor directories are added automatically, if they do not exist in the same layer yet.
+     * Adds a directory to the database. Ancestor directories are added automatically if they do not exist in the same layer yet.
      *
      * @param path the path of the directory relative to the storage root
      * @return the records that were added to the database for directories that did not exist yet
@@ -101,5 +101,13 @@ public interface LayerDatabase {
      * @return a list of layer IDs
      */
     List<Long> listLayerIds();
+
+    /**
+     * Gets all records for the given layer id.
+     *
+     * @param layerId the layer id to get records for
+     * @return a list of records for the given layer id
+     */
+    List<ItemRecord> getRecordsByLayerId(long layerId);
 
 }

--- a/src/main/java/nl/knaw/dans/layerstore/LayerDatabaseImpl.java
+++ b/src/main/java/nl/knaw/dans/layerstore/LayerDatabaseImpl.java
@@ -191,6 +191,16 @@ public class LayerDatabaseImpl implements LayerDatabase {
         return query.getResultList();
     }
 
+    @Override
+    public List<ItemRecord> getRecordsByLayerId(long layerId) {
+        CriteriaBuilder cb = persistenceProvider.getCriteriaBuilder();
+        CriteriaQuery<ItemRecord> cq = cb.createQuery(ItemRecord.class);
+        Root<ItemRecord> itemRecordRoot = cq.from(ItemRecord.class);
+        cq.select(itemRecordRoot).where(cb.equal(itemRecordRoot.get("layerId"), layerId));
+        TypedQuery<ItemRecord> query = persistenceProvider.createQuery(cq);
+        return query.getResultList();
+    }
+
     private String preprocessDirectoryArgument(String directoryPath) throws NoSuchFileException, NotDirectoryException {
         if (directoryPath == null) {
             throw new IllegalArgumentException("directoryPath must not be null");

--- a/src/main/java/nl/knaw/dans/layerstore/LayerDatabaseImpl.java
+++ b/src/main/java/nl/knaw/dans/layerstore/LayerDatabaseImpl.java
@@ -39,7 +39,7 @@ import static nl.knaw.dans.layerstore.Item.Type;
 @Slf4j
 public class LayerDatabaseImpl implements LayerDatabase {
     private PersistenceProvider<ItemRecord> persistenceProvider;
-    
+
     @Override
     public void saveRecords(ItemRecord... records) {
         for (var record : records) {
@@ -179,6 +179,16 @@ public class LayerDatabaseImpl implements LayerDatabase {
         cq.select(cb.literal(true)).where(cb.like(itemRecordRoot.get("path"), pathPattern));
         TypedQuery<Boolean> query = persistenceProvider.createQuery(cq);
         return query.getResultStream().findFirst().orElse(false);
+    }
+
+    @Override
+    public List<Long> listLayerIds() {
+        CriteriaBuilder cb = persistenceProvider.getCriteriaBuilder();
+        CriteriaQuery<Long> cq = cb.createQuery(Long.class);
+        Root<ItemRecord> itemRecordRoot = cq.from(ItemRecord.class);
+        cq.select(itemRecordRoot.get("layerId")).distinct(true);
+        TypedQuery<Long> query = persistenceProvider.createQuery(cq);
+        return query.getResultList();
     }
 
     private String preprocessDirectoryArgument(String directoryPath) throws NoSuchFileException, NotDirectoryException {

--- a/src/main/java/nl/knaw/dans/layerstore/LayerImpl.java
+++ b/src/main/java/nl/knaw/dans/layerstore/LayerImpl.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.Iterator;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -222,4 +223,13 @@ class LayerImpl implements Layer {
             throw new IllegalArgumentException("Path is outside staging directory");
     }
 
+    @Override
+    public Iterator<Item> listAllItems() throws IOException {
+        if (isArchived()) {
+            return archive.listAllItems();
+        }
+        else {
+            return new DirectoryTreeItemIterator(stagingDir);
+        }
+    }
 }

--- a/src/main/java/nl/knaw/dans/layerstore/LayerImpl.java
+++ b/src/main/java/nl/knaw/dans/layerstore/LayerImpl.java
@@ -56,14 +56,7 @@ class LayerImpl implements Layer {
     public void createDirectory(String path) throws IOException {
         checkOpen();
         validatePath(path);
-        ensureStagingDirExists();
         Files.createDirectories(stagingDir.resolve(path));
-    }
-
-    // TODO: should not be necessary, because the layer is initialized with an empty staging dir
-    private void ensureStagingDirExists() throws IOException {
-        if (!Files.exists(stagingDir))
-            Files.createDirectories(stagingDir);
     }
 
     public boolean isClosed() {
@@ -83,7 +76,6 @@ class LayerImpl implements Layer {
     @Override
     public void deleteFiles(List<String> paths) throws IOException {
         checkOpen();
-        ensureStagingDirExists();
         if (paths == null)
             throw new IllegalArgumentException("Paths cannot be null");
         for (String path : paths) {
@@ -93,8 +85,8 @@ class LayerImpl implements Layer {
     }
 
     /*
-     * This method is synchronized, because the layer might otherwise be closed just after the check. Note, that after the file handle is returned, the layer may be closed, but
-     * that is not a problem, because the file handle is still valid until it is closed, even if the directory containing the file is deleted.
+     * This method is synchronized because the layer might otherwise be closed just after the check. Note, that after the file handle is returned, the layer may be closed, but
+     * that is not a problem because the file handle is still valid until it is closed, even if the directory containing the file is deleted.
      */
     @Override
     public synchronized InputStream readFile(String path) throws IOException {
@@ -127,7 +119,6 @@ class LayerImpl implements Layer {
         checkClosed();
         checkNotReclosed();
         checkArchived();
-        ensureStagingDirExists();
         archive.unarchiveTo(stagingDir);
     }
 
@@ -185,14 +176,12 @@ class LayerImpl implements Layer {
     public void writeFile(String filePath, InputStream content) throws IOException {
         checkOpen();
         validatePath(filePath);
-        ensureStagingDirExists(); // TODO: not needed? Is taken care of by initialization of storage
         Files.copy(content, stagingDir.resolve(filePath), StandardCopyOption.REPLACE_EXISTING);
     }
 
     @Override
     public void moveDirectoryInto(Path source, String destination) throws IOException {
         checkOpen();
-        ensureStagingDirExists();
         validatePath(destination);
         var destinationPath = stagingDir.resolve(destination);
         Files.move(source, destinationPath);

--- a/src/main/java/nl/knaw/dans/layerstore/LayerManager.java
+++ b/src/main/java/nl/knaw/dans/layerstore/LayerManager.java
@@ -25,7 +25,7 @@ public interface LayerManager {
     /**
      * Closes the current top layer (if present) and creates a new top layer. The old top layer will be scheduled for archiving.
      */
-    void newTopLayer() throws IOException;
+    Layer newTopLayer() throws IOException;
 
     /**
      * Returns the current top layer.

--- a/src/main/java/nl/knaw/dans/layerstore/LayerManager.java
+++ b/src/main/java/nl/knaw/dans/layerstore/LayerManager.java
@@ -19,13 +19,13 @@ import java.io.IOException;
 import java.util.List;
 
 /**
- * Manages {@link Layer}s.
+ * Manages {@link Layer}s. Implementations of this interface should create new layers only through the `newTopLayer` method.
  */
 public interface LayerManager {
     /**
-     * Closes the current top layer and creates a new top layer. The old top layer will be scheduled for archiving.
+     * Closes the current top layer (if present) and creates a new top layer. The old top layer will be scheduled for archiving.
      */
-    void newTopLayer();
+    void newTopLayer() throws IOException;
 
     /**
      * Returns the current top layer.

--- a/src/main/java/nl/knaw/dans/layerstore/LayerManager.java
+++ b/src/main/java/nl/knaw/dans/layerstore/LayerManager.java
@@ -15,6 +15,9 @@
  */
 package nl.knaw.dans.layerstore;
 
+import java.io.IOException;
+import java.util.List;
+
 /**
  * Manages {@link Layer}s.
  */
@@ -33,4 +36,12 @@ public interface LayerManager {
      * @return the layer
      */
     Layer getLayer(long id);
+
+    /**
+     * Lists all layer IDs that are currently managed.
+     *
+     * @return a list of layer IDs
+     * @throws IOException if an I/O error occurs
+     */
+    List<Long> listLayerIds() throws IOException;
 }

--- a/src/main/java/nl/knaw/dans/layerstore/LayerManager.java
+++ b/src/main/java/nl/knaw/dans/layerstore/LayerManager.java
@@ -27,6 +27,11 @@ public interface LayerManager {
      */
     void newTopLayer();
 
+    /**
+     * Returns the current top layer.
+     *
+     * @return the current top layer
+     */
     Layer getTopLayer();
 
     /**

--- a/src/main/java/nl/knaw/dans/layerstore/LayerManagerImpl.java
+++ b/src/main/java/nl/knaw/dans/layerstore/LayerManagerImpl.java
@@ -55,6 +55,7 @@ public class LayerManagerImpl implements LayerManager {
                 .max()
                 .orElse(createNewTopLayer().getId());
             topLayer = new LayerImpl(id, stagingRoot.resolve(Long.toString(id)), archiveProvider.createArchive(id));
+            Files.createDirectories(stagingRoot.resolve(Long.toString(id)));
         }
     }
 
@@ -70,6 +71,13 @@ public class LayerManagerImpl implements LayerManager {
     }
 
     private Layer createNewTopLayer() {
+        // Wait 2 millis before creating a new top layer to avoid name collision
+        try {
+            Thread.sleep(2);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
         long id = System.currentTimeMillis();
         log.debug("Creating new top layer with id {}", id);
         return new LayerImpl(id, stagingRoot.resolve(Long.toString(id)), archiveProvider.createArchive(id));

--- a/src/main/java/nl/knaw/dans/layerstore/LayerManagerImpl.java
+++ b/src/main/java/nl/knaw/dans/layerstore/LayerManagerImpl.java
@@ -75,7 +75,7 @@ public class LayerManagerImpl implements LayerManager {
     }
 
     @Override
-    public void newTopLayer() throws IOException {
+    public Layer newTopLayer() throws IOException {
         var oldTopLayer = topLayer;
         // Wait 2 millis before creating a new top layer to avoid name collision
         try {
@@ -100,6 +100,7 @@ public class LayerManagerImpl implements LayerManager {
         else {
             log.debug("No old top layer to archive");
         }
+        return newLayer;
     }
 
     private void archive(Layer layer) {
@@ -119,8 +120,7 @@ public class LayerManagerImpl implements LayerManager {
 
     @Override
     public Layer getLayer(long id) {
-        if (id == topLayer.getId()) {
-            // safeguard/shortcut: a fresh top layer that never received content has no directory in the staging root
+        if (topLayer != null && id == topLayer.getId()) {
             return topLayer;
         }
         else if (stagingRoot.resolve(Long.toString(id)).toFile().exists() || archiveProvider.exists(id)) {

--- a/src/main/java/nl/knaw/dans/layerstore/LayerManagerImpl.java
+++ b/src/main/java/nl/knaw/dans/layerstore/LayerManagerImpl.java
@@ -22,6 +22,8 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -59,7 +61,7 @@ public class LayerManagerImpl implements LayerManager {
                 .mapToLong(Long::parseLong)
                 .max()
                 .orElse(createNewTopLayer().getId());
-            topLayer = new LayerImpl(id, stagingRoot.resolve(Long.toString(id)), archiveProvider.createArchive(Long.toString(id)));
+            topLayer = new LayerImpl(id, stagingRoot.resolve(Long.toString(id)), archiveProvider.createArchive(id));
         }
     }
 
@@ -67,7 +69,7 @@ public class LayerManagerImpl implements LayerManager {
         if (!path.toFile().isDirectory()) {
             throw new IllegalStateException("Not a directory: " + path);
         }
-        if(!path.getFileName().toString().matches("\\d{13,}")) {
+        if (!path.getFileName().toString().matches("\\d{13,}")) {
             // more than 13 digits in nov 2286, comma allows a longer future
             throw new IllegalStateException("Not a timestamp: " + path);
         }
@@ -77,7 +79,7 @@ public class LayerManagerImpl implements LayerManager {
     private Layer createNewTopLayer() {
         long id = System.currentTimeMillis();
         log.debug("Creating new top layer with id {}", id);
-        return new LayerImpl(id, stagingRoot.resolve(Long.toString(id)), archiveProvider.createArchive(Long.toString(id)));
+        return new LayerImpl(id, stagingRoot.resolve(Long.toString(id)), archiveProvider.createArchive(id));
     }
 
     @Override
@@ -101,14 +103,25 @@ public class LayerManagerImpl implements LayerManager {
         });
     }
 
+    public List<Long> listLayerIds() throws IOException {
+        try (var pathStream = Files.list(stagingRoot)) {
+            var allIds = new HashSet<>(pathStream
+                .map(this::toValidLayerName)
+                .map(Long::valueOf)
+                .toList());
+            allIds.addAll(archiveProvider.listArchivedLayers());
+            return allIds.stream().sorted().toList();
+        }
+    }
+
     @Override
     public Layer getLayer(long id) {
         if (id == topLayer.getId()) {
             // safeguard/shortcut: a fresh top layer that never received content has no directory in the staging root
             return topLayer;
         }
-        else if (stagingRoot.resolve(Long.toString(id)).toFile().exists() || archiveProvider.exists(Long.toString(id))) {
-            return new LayerImpl(id, stagingRoot.resolve(Long.toString(id)), archiveProvider.createArchive(Long.toString(id)));
+        else if (stagingRoot.resolve(Long.toString(id)).toFile().exists() || archiveProvider.exists(id)) {
+            return new LayerImpl(id, stagingRoot.resolve(Long.toString(id)), archiveProvider.createArchive(id));
         }
         else {
             throw new IllegalArgumentException("No layer found with id " + id);

--- a/src/main/java/nl/knaw/dans/layerstore/LayeredItemStore.java
+++ b/src/main/java/nl/knaw/dans/layerstore/LayeredItemStore.java
@@ -57,10 +57,32 @@ public class LayeredItemStore implements ItemStore {
         this.database = database;
         this.layerManager = layerManager;
         this.databaseBackedContentManager = Optional.ofNullable(databaseBackedContentManager).orElse(new NoopDatabaseBackedContentManager());
+        if (layerManager.getTopLayer() == null) {
+            try {
+                newTopLayer();
+            }
+            catch (IOException e) {
+                throw new IllegalStateException("Could not create top layer", e);
+            }
+        }
     }
 
     public LayeredItemStore(LayerDatabase database, LayerManager layerManager) {
         this(database, layerManager, null);
+    }
+
+    public Layer newTopLayer() throws IOException {
+        layerManager.newTopLayer();
+        database.addDirectory(layerManager.getTopLayer().getId(), "");
+        return layerManager.getTopLayer();
+    }
+
+    public Layer getLayer(long id) throws IOException {
+        return layerManager.getLayer(id);
+    }
+
+    public Layer getTopLayer() throws IOException {
+        return layerManager.getTopLayer();
     }
 
     public void checkSameLayersOnStorageAndDb() throws IOException {

--- a/src/main/java/nl/knaw/dans/layerstore/LayeredItemStore.java
+++ b/src/main/java/nl/knaw/dans/layerstore/LayeredItemStore.java
@@ -61,6 +61,33 @@ public class LayeredItemStore implements ItemStore {
         this(database, layerManager, null);
     }
 
+    public void checkSameLayerIdsFoundOnStorageAsInDatabase() throws IOException {
+        var layerIdsInDb = database.listLayerIds();
+        var layerIdsOnStorage = layerManager.listLayerIds();
+        var missingInDb = new ArrayList<Long>();
+        for (var id : layerIdsOnStorage) {
+            if (!layerIdsInDb.contains(id)) {
+                missingInDb.add(id);
+            }
+        }
+        var missingOnStorage = new ArrayList<Long>();
+        for (var id : layerIdsInDb) {
+            if (!layerIdsOnStorage.contains(id)) {
+                missingOnStorage.add(id);
+            }
+        }
+        if (!missingInDb.isEmpty() || !missingOnStorage.isEmpty()) {
+            var message = "Layer IDs are inconsistent between database and storage.";
+            if (!missingInDb.isEmpty()) {
+                message += " Missing in database: " + missingInDb;
+            }
+            if (!missingOnStorage.isEmpty()) {
+                message += " Missing on storage: " + missingOnStorage;
+            }
+            throw new IllegalStateException(message);
+        }
+    }
+
     @Override
     public List<Item> listDirectory(String directoryPath) throws IOException {
         return database.listDirectory(directoryPath);

--- a/src/main/java/nl/knaw/dans/layerstore/LayeredItemStore.java
+++ b/src/main/java/nl/knaw/dans/layerstore/LayeredItemStore.java
@@ -36,10 +36,10 @@ import static nl.knaw.dans.layerstore.Utils.throwOnListDifference;
 
 /**
  * An implementation of FileStore that stores files and directories as a stack of layers. A layer can be staged or archived. Staged layers can be modified, archived layers are read-only. To transform
- * the layered file store into a regular file system directory, each layer must be unarchived (if it was archived) to a staging directory and the staging directories must be copied into a single
+ * the layered file store into a regular file system directory, each layer must be unarchived (if it was archived) to a staging directory. The staging directories must be copied into a single
  * directory, starting with the oldest layer and ending with the newest layer. Files in newer layers overwrite files in older layers.
  * <p>
- * The LayeredFileStore is backed by a LayerDatabase to support storage of layers in a way that may not be fast enough for direct access, for example on tape. See the LayerDatabase interface for more
+ * The LayeredFileStore is backed by a LayerDatabase to support storage of layers in a way that may not be fast enough for direct access, for example, on tape. See the LayerDatabase interface for more
  * information.
  *
  * @see LayerDatabase
@@ -57,14 +57,14 @@ public class LayeredItemStore implements ItemStore {
         this.database = database;
         this.layerManager = layerManager;
         this.databaseBackedContentManager = Optional.ofNullable(databaseBackedContentManager).orElse(new NoopDatabaseBackedContentManager());
-        if (layerManager.getTopLayer() == null) {
-            try {
-                newTopLayer();
-            }
-            catch (IOException e) {
-                throw new IllegalStateException("Could not create top layer", e);
-            }
-        }
+//        if (layerManager.getTopLayer() == null) {
+//            try {
+//                newTopLayer();
+//            }
+//            catch (IOException e) {
+//                throw new IllegalStateException("Could not create top layer", e);
+//            }
+//        }
     }
 
     public LayeredItemStore(LayerDatabase database, LayerManager layerManager) {

--- a/src/main/java/nl/knaw/dans/layerstore/LayeredItemStore.java
+++ b/src/main/java/nl/knaw/dans/layerstore/LayeredItemStore.java
@@ -293,7 +293,7 @@ public class LayeredItemStore implements ItemStore {
     @Override
     public void copyDirectoryOutOf(String source, Path destination) throws IOException {
         var items = database.listRecursive(source);
-        // Sort by ascending path length, so that we start with the deepest directories
+        // Sort by ascending path length so that we start with the deepest directories
         items.sort(Comparator.comparingInt(listingRecord -> Path.of(listingRecord.getPath()).getNameCount()));
         if (!items.isEmpty()) {
             var deepestDirectory = Path.of(items.get(0).getPath()).getParent();

--- a/src/main/java/nl/knaw/dans/layerstore/SshRunner.java
+++ b/src/main/java/nl/knaw/dans/layerstore/SshRunner.java
@@ -19,6 +19,7 @@ import lombok.AllArgsConstructor;
 import nl.knaw.dans.lib.util.ProcessRunner;
 
 import java.nio.file.Path;
+import java.util.List;
 
 @AllArgsConstructor
 public class SshRunner {
@@ -33,5 +34,16 @@ public class SshRunner {
             "test", "-e", remoteBaseDir.resolve(archiveName).toString());
         var result = runner.runToEnd();
         return result.getExitCode() == 0;
+    }
+
+    public List<String> listFiles() {
+        var runner = new ProcessRunner(sshExecutable.toAbsolutePath().toString(),
+            user + "@" + host,
+            "ls -1", remoteBaseDir.toString());
+        var result = runner.runToEnd();
+        if (result.getExitCode() != 0) {
+            throw new RuntimeException("Failed to list files in " + remoteBaseDir + " on " + host + ": " + result);
+        }
+        return result.getStandardOutput().lines().toList();
     }
 }

--- a/src/main/java/nl/knaw/dans/layerstore/SshRunner.java
+++ b/src/main/java/nl/knaw/dans/layerstore/SshRunner.java
@@ -15,7 +15,6 @@
  */
 package nl.knaw.dans.layerstore;
 
-import lombok.AllArgsConstructor;
 import nl.knaw.dans.lib.util.ProcessInputStream;
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.DefaultExecutor;
@@ -27,20 +26,33 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
 
-@AllArgsConstructor
 public class SshRunner extends AbstractRunner {
     private final Path sshExecutable;
     private final String user;
     private final String host;
     private final Path remoteBaseDir;
+    private final int connectionTimeout; // seconds
+
+    public SshRunner(Path sshExecutable, String user, String host, Path remoteBaseDir) {
+        this(sshExecutable, user, host, remoteBaseDir, 10);
+    }
+
+    public SshRunner(Path sshExecutable, String user, String host, Path remoteBaseDir, int connectionTimeout) {
+        this.sshExecutable = Path.of(checkExecutableForSecurity(sshExecutable));
+        this.user = checkUserOrHostNameForSecurity(user);
+        this.host = checkUserOrHostNameForSecurity(host);
+        this.remoteBaseDir = Path.of(checkRemoteBaseDirForSecurity(remoteBaseDir.toString()));
+        this.connectionTimeout = connectionTimeout;
+    }
 
     public boolean fileExists(String archiveName) {
-        var command = String.format("%s %s@test %s -e %s",
-            sshExecutable.toAbsolutePath(),
-            checkUserOrHostNameForSecurity(user),
-            checkUserOrHostNameForSecurity(host),
-            checkRemoteBaseDirForSecurity(remoteBaseDir.resolve(archiveName).toString()));
-        var cmdLine = CommandLine.parse(command);
+        var cmdLine = new CommandLine(sshExecutable.toAbsolutePath().toString())
+            .addArgument("-o")
+            .addArgument("BatchMode=yes")
+            .addArgument("-o")
+            .addArgument("ConnectTimeout=" + connectionTimeout)
+            .addArgument(user + "@" + host)
+            .addArgument("/usr/bin/test -e '" + remoteBaseDir.resolve(archiveName) + "'", false);
         var executor = DefaultExecutor.builder().get();
         executor.setExitValues(new int[] { 0, 1 });
         try {
@@ -54,13 +66,14 @@ public class SshRunner extends AbstractRunner {
 
     public List<String> listFiles() {
         try {
-            var command = String.format("%s %s@%s ls -1 %s",
-                sshExecutable.toAbsolutePath(),
-                checkUserOrHostNameForSecurity(user),
-                checkUserOrHostNameForSecurity(host),
-                checkRemoteBaseDirForSecurity(remoteBaseDir.toString()));
-            var cmdLine = CommandLine.parse(command);
-
+            var cmdLine = new CommandLine(sshExecutable.toAbsolutePath().toString())
+                .addArgument("-o")
+                .addArgument("BatchMode=yes")
+                .addArgument("-o")
+                .addArgument("ConnectTimeout=" + connectionTimeout)
+                .addArgument(user + "@" + host)
+                .addArgument("ls -1", false)
+                .addArgument(remoteBaseDir.toString());
             try (var in = ProcessInputStream.start(cmdLine);
                 var reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
                 return reader.lines().toList();

--- a/src/main/java/nl/knaw/dans/layerstore/SshRunner.java
+++ b/src/main/java/nl/knaw/dans/layerstore/SshRunner.java
@@ -16,16 +16,19 @@
 package nl.knaw.dans.layerstore;
 
 import lombok.AllArgsConstructor;
+import nl.knaw.dans.lib.util.ProcessInputStream;
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.DefaultExecutor;
 
-import java.io.ByteArrayOutputStream;
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
 
 @AllArgsConstructor
-public class SshRunner {
+public class SshRunner extends AbstractRunner {
     private final Path sshExecutable;
     private final String user;
     private final String host;
@@ -34,9 +37,9 @@ public class SshRunner {
     public boolean fileExists(String archiveName) {
         var command = String.format("%s %s@test %s -e %s",
             sshExecutable.toAbsolutePath(),
-            user,
-            host,
-            remoteBaseDir.resolve(archiveName));
+            checkUserOrHostNameForSecurity(user),
+            checkUserOrHostNameForSecurity(host),
+            checkRemoteBaseDirForSecurity(remoteBaseDir.resolve(archiveName).toString()));
         var cmdLine = CommandLine.parse(command);
         var executor = DefaultExecutor.builder().get();
         executor.setExitValues(new int[] { 0, 1 });
@@ -49,20 +52,22 @@ public class SshRunner {
         }
     }
 
-    public List<String> listFiles() throws IOException {
-        var command = String.format("%s %s@%s ls -1 %s",
-            sshExecutable.toAbsolutePath(),
-            user,
-            host,
-            remoteBaseDir);
-        var cmdLine = CommandLine.parse(command);
-        var executor = DefaultExecutor.builder().get();
-        var outputStream = new ByteArrayOutputStream();
-        executor.setStreamHandler(new org.apache.commons.exec.PumpStreamHandler(outputStream));
-        int exitValue = executor.execute(cmdLine);
-        if (exitValue != 0) {
-            throw new RuntimeException("Failed to list files in " + remoteBaseDir + " on " + host + ": exit code " + exitValue);
+    public List<String> listFiles() {
+        try {
+            var command = String.format("%s %s@%s ls -1 %s",
+                sshExecutable.toAbsolutePath(),
+                checkUserOrHostNameForSecurity(user),
+                checkUserOrHostNameForSecurity(host),
+                checkRemoteBaseDirForSecurity(remoteBaseDir.toString()));
+            var cmdLine = CommandLine.parse(command);
+
+            try (var in = ProcessInputStream.start(cmdLine);
+                var reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
+                return reader.lines().toList();
+            }
         }
-        return outputStream.toString().lines().toList();
+        catch (IOException e) {
+            throw new RuntimeException("Failed to list files in " + remoteBaseDir + " on " + host + ": " + e.getMessage(), e);
+        }
     }
 }

--- a/src/main/java/nl/knaw/dans/layerstore/TarArchive.java
+++ b/src/main/java/nl/knaw/dans/layerstore/TarArchive.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.util.Iterator;
 import java.util.stream.Stream;
 
 import static java.text.MessageFormat.format;
@@ -145,5 +146,10 @@ public class TarArchive implements Archive {
         catch (NoSuchFileException | FileNotFoundException e) {
             return false;
         }
+    }
+
+    @Override
+    public Iterator<Item> listAllItems() {
+        return null;
     }
 }

--- a/src/main/java/nl/knaw/dans/layerstore/TarArchiveItemIterator.java
+++ b/src/main/java/nl/knaw/dans/layerstore/TarArchiveItemIterator.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.layerstore;
+
+import lombok.NonNull;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarFile;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Iterator;
+
+public class TarArchiveItemIterator implements Iterator<Item> {
+    private final TarFile tarFile;
+    private final Iterator<TarArchiveEntry> entries;
+
+    /**
+     * The root item represents the root of the zip archive, and is implicitly present in every zip archive.
+     */
+    private final Item rootItem = new Item("", Item.Type.Directory);
+
+    private boolean rootReturned = false;
+
+    public TarArchiveItemIterator(@NonNull Path tarFile) throws IOException {
+        this.tarFile = new TarFile(tarFile.toFile());
+        this.entries = this.tarFile.getEntries().iterator();
+
+    }
+
+    @Override
+    public boolean hasNext() {
+        if (!rootReturned) {
+            return true;
+        }
+        return entries.hasNext();
+    }
+
+    @Override
+    @SuppressWarnings("ThrowFromFinallyBlock")
+    public Item next() {
+        try {
+            if (!rootReturned) {
+                rootReturned = true;
+                return rootItem;
+            }
+            var next = entries.next();
+            // Remove trailing slash from directory names
+            var name = next.getName();
+            if (next.isDirectory() && name.endsWith("/")) {
+                name = name.substring(0, name.length() - 1);
+            }
+            return new Item(name, next.isDirectory() ? Item.Type.Directory : Item.Type.File);
+        }
+        finally {
+            if (!hasNext()) {
+                try {
+                    tarFile.close();
+                }
+                catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/nl/knaw/dans/layerstore/TarArchiveProvider.java
+++ b/src/main/java/nl/knaw/dans/layerstore/TarArchiveProvider.java
@@ -17,6 +17,8 @@ package nl.knaw.dans.layerstore;
 
 import lombok.AllArgsConstructor;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -36,7 +38,7 @@ public class TarArchiveProvider implements ArchiveProvider {
 
     @Override
     public List<Long> listArchivedLayers() {
-        try(var stream = java.nio.file.Files.list(archiveRoot)) {
+        try (var stream = Files.list(archiveRoot)) {
             return stream
                 .map(Path::getFileName)
                 .map(Path::toString)
@@ -44,7 +46,8 @@ public class TarArchiveProvider implements ArchiveProvider {
                 .map(name -> name.substring(0, name.length() - ".tar".length()))
                 .map(Long::valueOf)
                 .toList();
-        } catch (java.io.IOException e) {
+        }
+        catch (IOException e) {
             throw new RuntimeException("Failed to list files in archive root: " + archiveRoot, e);
         }
     }

--- a/src/main/java/nl/knaw/dans/layerstore/TarArchiveProvider.java
+++ b/src/main/java/nl/knaw/dans/layerstore/TarArchiveProvider.java
@@ -37,7 +37,7 @@ public class TarArchiveProvider implements ArchiveProvider {
     }
 
     @Override
-    public List<Long> listArchivedLayers() {
+    public List<Long> listArchivedLayers() throws IOException {
         try (var stream = Files.list(archiveRoot)) {
             return stream
                 .map(Path::getFileName)
@@ -46,9 +46,6 @@ public class TarArchiveProvider implements ArchiveProvider {
                 .map(name -> name.substring(0, name.length() - ".tar".length()))
                 .map(Long::valueOf)
                 .toList();
-        }
-        catch (IOException e) {
-            throw new RuntimeException("Failed to list files in archive root: " + archiveRoot, e);
         }
     }
 }

--- a/src/main/java/nl/knaw/dans/layerstore/Utils.java
+++ b/src/main/java/nl/knaw/dans/layerstore/Utils.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.layerstore;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Utils {
+
+    public static <T> void throwOnListDifference(List<T> databaseList, List<T> storageList, String baseMessage) {
+        var missingInDb = new ArrayList<T>();
+        for (var id : storageList) {
+            if (!databaseList.contains(id)) {
+                missingInDb.add(id);
+            }
+        }
+        var missingOnStorage = new ArrayList<T>();
+        for (var id : databaseList) {
+            if (!storageList.contains(id)) {
+                missingOnStorage.add(id);
+            }
+        }
+        if (!missingInDb.isEmpty() || !missingOnStorage.isEmpty()) {
+            var message = baseMessage;
+            if (!missingInDb.isEmpty()) {
+                message += " Missing in database: " + missingInDb;
+            }
+            if (!missingOnStorage.isEmpty()) {
+                message += " Missing on storage: " + missingOnStorage;
+            }
+            throw new IllegalStateException(message);
+        }
+    }
+}

--- a/src/main/java/nl/knaw/dans/layerstore/ZipArchive.java
+++ b/src/main/java/nl/knaw/dans/layerstore/ZipArchive.java
@@ -32,6 +32,7 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.stream.Stream;
 
 import static java.text.MessageFormat.format;
@@ -144,5 +145,10 @@ public class ZipArchive implements Archive {
         catch (NoSuchFileException | FileNotFoundException e) {
             return false;
         }
+    }
+
+    @Override
+    public Iterator<Item> listAllItems() throws IOException {
+        return new ZipArchiveItemIterator(zipFile);
     }
 }

--- a/src/main/java/nl/knaw/dans/layerstore/ZipArchiveItemIterator.java
+++ b/src/main/java/nl/knaw/dans/layerstore/ZipArchiveItemIterator.java
@@ -25,6 +25,12 @@ import java.util.Iterator;
 
 public class ZipArchiveItemIterator implements Iterator<Item> {
     private final Iterator<ZipArchiveEntry> entries;
+    /**
+     * The root item represents the root of the zip archive, and is implicitly present in every zip archive.
+     */
+    private final Item rootItem = new Item("", Item.Type.Directory);
+
+    private boolean rootReturned = false;
 
     public ZipArchiveItemIterator(@NonNull Path zipFile) throws IOException {
         var zip = ZipFile.builder()
@@ -35,11 +41,18 @@ public class ZipArchiveItemIterator implements Iterator<Item> {
 
     @Override
     public boolean hasNext() {
+        if (!rootReturned) {
+            return true;
+        }
         return entries.hasNext();
     }
 
     @Override
     public Item next() {
+        if (!rootReturned) {
+            rootReturned = true;
+            return rootItem;
+        }
         var next = entries.next();
         return new Item(next.getName(),
             next.isDirectory() ? Item.Type.Directory : Item.Type.File);

--- a/src/main/java/nl/knaw/dans/layerstore/ZipArchiveItemIterator.java
+++ b/src/main/java/nl/knaw/dans/layerstore/ZipArchiveItemIterator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.layerstore;
+
+import lombok.NonNull;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipFile;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Iterator;
+
+public class ZipArchiveItemIterator implements Iterator<Item> {
+    private final Iterator<ZipArchiveEntry> entries;
+
+    public ZipArchiveItemIterator(@NonNull Path zipFile) throws IOException {
+        var zip = ZipFile.builder()
+            .setFile(zipFile.toFile())
+            .get();
+        entries = zip.getEntries().asIterator();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return entries.hasNext();
+    }
+
+    @Override
+    public Item next() {
+        var next = entries.next();
+        return new Item(next.getName(),
+            next.isDirectory() ? Item.Type.Directory : Item.Type.File);
+    }
+}

--- a/src/main/java/nl/knaw/dans/layerstore/ZipArchiveProvider.java
+++ b/src/main/java/nl/knaw/dans/layerstore/ZipArchiveProvider.java
@@ -18,18 +18,35 @@ package nl.knaw.dans.layerstore;
 import lombok.AllArgsConstructor;
 
 import java.nio.file.Path;
+import java.util.List;
 
 @AllArgsConstructor
 public class ZipArchiveProvider implements ArchiveProvider {
     private final Path archiveRoot;
 
     @Override
-    public Archive createArchive(String path) {
-        return new ZipArchive(archiveRoot.resolve(path + ".zip"));
+    public Archive createArchive(long layerId) {
+        return new ZipArchive(archiveRoot.resolve(layerId + ".zip"));
     }
 
     @Override
-    public boolean exists(String path) {
-        return archiveRoot.resolve(path + ".zip").toFile().exists();
+    public boolean exists(long layerId) {
+        return archiveRoot.resolve(layerId + ".zip").toFile().exists();
+    }
+
+    @Override
+    public List<Long> listArchivedLayers() {
+        try (var stream = java.nio.file.Files.list(archiveRoot)) {
+            return stream
+                .map(Path::getFileName)
+                .map(Path::toString)
+                .filter(name -> name.endsWith(".zip"))
+                .map(name -> name.substring(0, name.length() - ".zip".length()))
+                .map(Long::valueOf)
+                .toList();
+        }
+        catch (java.io.IOException e) {
+            throw new RuntimeException("Failed to list files in archive root: " + archiveRoot, e);
+        }
     }
 }

--- a/src/main/java/nl/knaw/dans/layerstore/ZipArchiveProvider.java
+++ b/src/main/java/nl/knaw/dans/layerstore/ZipArchiveProvider.java
@@ -17,6 +17,7 @@ package nl.knaw.dans.layerstore;
 
 import lombok.AllArgsConstructor;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -35,7 +36,7 @@ public class ZipArchiveProvider implements ArchiveProvider {
     }
 
     @Override
-    public List<Long> listArchivedLayers() {
+    public List<Long> listArchivedLayers() throws IOException {
         try (var stream = java.nio.file.Files.list(archiveRoot)) {
             return stream
                 .map(Path::getFileName)
@@ -44,9 +45,6 @@ public class ZipArchiveProvider implements ArchiveProvider {
                 .map(name -> name.substring(0, name.length() - ".zip".length()))
                 .map(Long::valueOf)
                 .toList();
-        }
-        catch (java.io.IOException e) {
-            throw new RuntimeException("Failed to list files in archive root: " + archiveRoot, e);
         }
     }
 }

--- a/src/test/java/nl/knaw/dans/layerstore/AbstractTestWithTestDir.java
+++ b/src/test/java/nl/knaw/dans/layerstore/AbstractTestWithTestDir.java
@@ -19,6 +19,7 @@ import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 /**
@@ -44,6 +45,7 @@ public abstract class AbstractTestWithTestDir {
             // github stumbled: https://github.com/DANS-KNAW/dans-layer-store-lib/actions/runs/8705753485/job/23876831089?pr=7#step:4:106
             FileUtils.deleteDirectory(testDir.toFile());
         }
+        Files.createDirectories(testDir);
     }
 
     public void createEmptyStagingDirFiles(String... paths) {

--- a/src/test/java/nl/knaw/dans/layerstore/DirectoryTreeItemIteratorTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/DirectoryTreeItemIteratorTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.layerstore;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DirectoryTreeItemIteratorTest extends AbstractTestWithTestDir {
+
+    @Test
+    public void should_yield_only_starting_dir_if_it_is_empty() throws Exception {
+        // Given
+        var iterator = new DirectoryTreeItemIterator(testDir);
+
+        // When - Then
+        var actualPaths = new HashSet<String>();
+        while (iterator.hasNext()) {
+            actualPaths.add(iterator.next().getPath());
+        }
+        assertThat(actualPaths).containsExactly("");
+    }
+
+    @Test
+    public void should_yield_files_and_directories_in_a_directory_tree() throws Exception {
+        // Given
+        createStagingFileWithContent("a/b/c/d/test1.txt", "Hello world!");
+        createStagingFileWithContent("a/b/c/test2.txt", "Hello again!");
+        createStagingFileWithContent("a/b/test3.txt", "Hello once more!");
+        createStagingFileWithContent("a/test4.txt", "Hello for the last time!");
+        var iterator = new DirectoryTreeItemIterator(stagingDir);
+
+        // When - Then
+        var actualPaths = new HashSet<String>();
+        while (iterator.hasNext()) {
+            actualPaths.add(iterator.next().getPath());
+        }
+        assertThat(actualPaths).containsExactlyInAnyOrder(
+            "",
+            "a",
+            "a/b",
+            "a/b/c",
+            "a/b/c/d",
+            "a/b/c/d/test1.txt",
+            "a/b/c/test2.txt",
+            "a/b/test3.txt",
+            "a/test4.txt"
+        );
+    }
+
+}

--- a/src/test/java/nl/knaw/dans/layerstore/DmfTarArchiveItemIteratorTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/DmfTarArchiveItemIteratorTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.layerstore;
+
+import org.apache.commons.collections4.IteratorUtils;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+
+public class DmfTarArchiveItemIteratorTest {
+    private DmfTarRunner dmfTarRunnerMock = Mockito.mock(DmfTarRunner.class);
+
+    @Test
+    public void should_strip_everything_before_dot_slash_from_paths_and_remove_dmftar_cache_entries() {
+        Mockito.when(dmfTarRunnerMock.listFiles(any())).thenReturn(
+            Arrays.stream("""
+                drwxrwxr-x janm/janm         0 2025-09-05 14:12 ./
+                drwxrwxr-x janm/janm         0 2025-07-14 11:25 ./text/
+                -rw-rw-r-- janm/janm      4777 2025-07-14 11:25 ./text/loro.txt
+                -rw-rw-r-- janm/janm   3175083 2025-07-14 11:25 ./Tarantula_Nebula_-_Hubble.jpg
+                drwxrwxr-x janm/janm         0 2025-09-05 14:12 ./dmftar-cache.28581/
+                drwxrwxr-x janm/janm         0 2025-09-05 14:12 ./dmftar-cache.28581/1757074305443.dmftar/
+                drwxr-x--- janm/janm         0 2025-09-05 14:12 ./dmftar-cache.28581/1757074305443.dmftar/0000/
+                -rw-rw-r-- janm/janm     52488 2025-07-14 11:25 ./loro.jpeg
+                -rw-rw-r-- janm/janm    846800 2025-07-14 11:25 ./space-galaxy.jpg
+                -rw-rw-r-- janm/janm    516658 2025-07-14 11:25 ./space-galaxy-1401467040F0s.jpg
+                """.split("\n")).iterator());
+
+        var list = IteratorUtils.toList(new DmfTarArchiveItemIterator("some-archive.dmftar", dmfTarRunnerMock));
+        assertThat(list).asList()
+            .containsExactlyInAnyOrder(
+                new Item("", Item.Type.Directory),
+                new Item("text", Item.Type.Directory),
+                new Item("text/loro.txt", Item.Type.File),
+                new Item("Tarantula_Nebula_-_Hubble.jpg", Item.Type.File),
+                new Item("loro.jpeg", Item.Type.File),
+                new Item("space-galaxy.jpg", Item.Type.File),
+                new Item("space-galaxy-1401467040F0s.jpg", Item.Type.File)
+            );
+    }
+
+}

--- a/src/test/java/nl/knaw/dans/layerstore/DmfTarRunnerLiveTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/DmfTarRunnerLiveTest.java
@@ -70,24 +70,15 @@ public class DmfTarRunnerLiveTest {
         assertThat(actual).isEqualTo(expected);
     }
 
-    /*
-     *  * dmftar.executable = /path/to/dmf-tar
-     * dmftar.remote-base-dir = /path/to/remote-base-dir
-     * dmftar.user = user
-     * dmftar.host = host
-
-     */
-
-
     @Test
     @EnabledIf("nl.knaw.dans.layerstore.TestConditions#dmftarLiveTestConfigured")
     public void listFilesInTar() throws Exception {
-        //var tarFile = System.currentTimeMillis() + ".dmftar";
-        var tarFile = "1756905354381.dmftar";
-        log.debug("tarFile: {}", tarFile);
-//        dmfTarRunner.tarDirectory(inputDir, tarFile);
+        var dmfTarFile = System.currentTimeMillis() + ".dmftar";
+        log.debug("Creating tar file: {}", dmfTarFile);
+        dmfTarRunner.tarDirectory(inputDir, dmfTarFile);
+        log.debug("Created tar file: {}", dmfTarFile);
         try {
-            var list = IteratorUtils.toList(dmfTarRunner.listFiles(tarFile));
+            var list = IteratorUtils.toList(new DmfTarArchiveItemIterator(dmfTarFile, dmfTarRunner));
             assertThat(list).asList().containsExactlyInAnyOrder(
                 "",
                 "loro.jpeg",

--- a/src/test/java/nl/knaw/dans/layerstore/DmfTarRunnerLiveTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/DmfTarRunnerLiveTest.java
@@ -65,7 +65,7 @@ public class DmfTarRunnerLiveTest {
         var tarFile = System.currentTimeMillis() + ".dmftar";
         log.debug("tarFile: {}", tarFile);
         dmfTarRunner.tarDirectory(inputDir, tarFile);
-        var actual = IOUtils.toString(dmfTarRunner.readFile(tarFile, "./text/loro.txt"), StandardCharsets.UTF_8);
+        var actual = IOUtils.toString(dmfTarRunner.readFile(tarFile, "text/loro.txt"), StandardCharsets.UTF_8);
         var expected = FileUtils.readFileToString(new File("src/test/resources/live-test-input-dir/text/loro.txt"), StandardCharsets.UTF_8);
         assertThat(actual).isEqualTo(expected);
     }
@@ -80,13 +80,13 @@ public class DmfTarRunnerLiveTest {
         try {
             var list = IteratorUtils.toList(new DmfTarArchiveItemIterator(dmfTarFile, dmfTarRunner));
             assertThat(list).asList().containsExactlyInAnyOrder(
-                "",
-                "loro.jpeg",
-                "space-galaxy.jpg",
-                "space-galaxy-1401467040F0s.jpg",
-                "Tarantula_Nebula_-_Hubble.jpg",
-                "text/",
-                "text/loro.txt"
+                new Item("", Item.Type.Directory),
+                new Item("loro.jpeg", Item.Type.File),
+                new Item("space-galaxy.jpg", Item.Type.File),
+                new Item("space-galaxy-1401467040F0s.jpg", Item.Type.File),
+                new Item("Tarantula_Nebula_-_Hubble.jpg", Item.Type.File),
+                new Item("text", Item.Type.Directory),
+                new Item("text/loro.txt", Item.Type.File)
             );
         } catch (Exception e) {
             log.error("Caught exception", e);

--- a/src/test/java/nl/knaw/dans/layerstore/DmfTarRunnerLiveTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/DmfTarRunnerLiveTest.java
@@ -16,6 +16,7 @@
 package nl.knaw.dans.layerstore;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.IteratorUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -60,12 +61,45 @@ public class DmfTarRunnerLiveTest {
 
     @Test
     @EnabledIf("nl.knaw.dans.layerstore.TestConditions#dmftarLiveTestConfigured")
-    public void roundTrip() throws Exception {
+    public void createTarAndReadTarRoundTrip() throws Exception {
         var tarFile = System.currentTimeMillis() + ".dmftar";
         log.debug("tarFile: {}", tarFile);
         dmfTarRunner.tarDirectory(inputDir, tarFile);
         var actual = IOUtils.toString(dmfTarRunner.readFile(tarFile, "./text/loro.txt"), StandardCharsets.UTF_8);
         var expected = FileUtils.readFileToString(new File("src/test/resources/live-test-input-dir/text/loro.txt"), StandardCharsets.UTF_8);
         assertThat(actual).isEqualTo(expected);
+    }
+
+    /*
+     *  * dmftar.executable = /path/to/dmf-tar
+     * dmftar.remote-base-dir = /path/to/remote-base-dir
+     * dmftar.user = user
+     * dmftar.host = host
+
+     */
+
+
+    @Test
+    @EnabledIf("nl.knaw.dans.layerstore.TestConditions#dmftarLiveTestConfigured")
+    public void listFilesInTar() throws Exception {
+        //var tarFile = System.currentTimeMillis() + ".dmftar";
+        var tarFile = "1756905354381.dmftar";
+        log.debug("tarFile: {}", tarFile);
+//        dmfTarRunner.tarDirectory(inputDir, tarFile);
+        try {
+            var list = IteratorUtils.toList(dmfTarRunner.listFiles(tarFile));
+            assertThat(list).asList().containsExactlyInAnyOrder(
+                "",
+                "loro.jpeg",
+                "space-galaxy.jpg",
+                "space-galaxy-1401467040F0s.jpg",
+                "Tarantula_Nebula_-_Hubble.jpg",
+                "text/",
+                "text/loro.txt"
+            );
+        } catch (Exception e) {
+            log.error("Caught exception", e);
+            throw e;
+        }
     }
 }

--- a/src/test/java/nl/knaw/dans/layerstore/LayerArchiveTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerArchiveTest.java
@@ -27,29 +27,42 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 public class LayerArchiveTest extends AbstractCapturingTest {
     @Test
-    public void throws_IllegalStateException_when_layer_is_closed() {
+    public void throws_IllegalStateException_when_layer_is_not_closed() throws Exception {
+        // Given
+        Files.createDirectories(stagingDir);
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
+
+        // When / Then
         assertThatThrownBy(layer::archive)
-            .isInstanceOf(IllegalStateException.class);
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Layer is open, but must be closed for this operation");
     }
 
     @Test
     public void throws_IllegalStateException_when_layer_is_already_archived() throws IOException {
+        // Given
         Files.createDirectories(archiveDir);
         Files.createDirectories(stagingDir);
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         layer.close();
         layer.archive();
+
+        // When / Then
         assertThatThrownBy(layer::archive)
-            .isInstanceOf(IllegalStateException.class);
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Layer is already archived");
     }
 
     @Test
-    public void throws_RuntimeException_caused_by_an_IOException() {
+    public void throws_RuntimeException_if_archive_root_does_not_exist() throws Exception {
+        // Given
+        // NOTE: archiveDir is not created
         var testZip = archiveDir.resolve("test.zip");
+        Files.createDirectories(stagingDir);
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(testZip));
         layer.close();
 
+        // When / Then
         assertThatThrownBy(layer::archive)
             .isInstanceOf(RuntimeException.class)
             .hasRootCauseInstanceOf(NoSuchFileException.class)
@@ -61,14 +74,17 @@ public class LayerArchiveTest extends AbstractCapturingTest {
 
     @Test
     public void removes_staging_dir() throws IOException {
+        // Given
         Files.createDirectories(archiveDir);
+        Files.createDirectories(stagingDir);
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
-        assertThat(stagingDir).doesNotExist();
         createEmptyStagingDirFiles("path/to/file1");
-        assertThat(stagingDir).exists();
         layer.close();
 
+        // When
         layer.archive();
+
+        // Then
         assertThat(stagingDir).doesNotExist();
     }
 }

--- a/src/test/java/nl/knaw/dans/layerstore/LayerCloseTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerCloseTest.java
@@ -26,18 +26,26 @@ public class LayerCloseTest extends AbstractTestWithTestDir {
 
     @Test
     public void throws_IllegalStateException_when_layer_is_already_closed() throws Exception {
+        // Given
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         Files.createDirectories(stagingDir);
         layer.close();
+
+        // When / Then
         assertThatThrownBy(layer::close)
             .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
     public void should_close_layer() throws Exception {
+        // Given
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         Files.createDirectories(stagingDir);
+
+        // When
         layer.close();
+
+        // Then
         assertThat(layer.isClosed()).isTrue();
     }
 

--- a/src/test/java/nl/knaw/dans/layerstore/LayerCloseTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerCloseTest.java
@@ -17,22 +17,26 @@ package nl.knaw.dans.layerstore;
 
 import org.junit.jupiter.api.Test;
 
+import java.nio.file.Files;
+
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 public class LayerCloseTest extends AbstractTestWithTestDir {
 
     @Test
-    public void throws_IllegalStateException_when_layer_is_already_closed() {
+    public void throws_IllegalStateException_when_layer_is_already_closed() throws Exception {
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
+        Files.createDirectories(stagingDir);
         layer.close();
         assertThatThrownBy(layer::close)
             .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
-    public void should_close_layer() {
+    public void should_close_layer() throws Exception {
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
+        Files.createDirectories(stagingDir);
         layer.close();
         assertThat(layer.isClosed()).isTrue();
     }

--- a/src/test/java/nl/knaw/dans/layerstore/LayerCreateDirectoryTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerCreateDirectoryTest.java
@@ -17,52 +17,69 @@ package nl.knaw.dans.layerstore;
 
 import org.junit.jupiter.api.Test;
 
+import java.nio.file.Files;
+
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 public class LayerCreateDirectoryTest extends AbstractTestWithTestDir {
     @Test
     public void should_create_directories_in_staging_dir_if_layer_is_open() throws Exception {
+        // Given
+        Files.createDirectories(stagingDir);
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
+
+        // When
         layer.createDirectory("path/to/directory");
+
+        // Then
         assertThat(stagingDir.resolve("path/to/directory")).exists();
     }
 
     @Test
-    public void should_throw_IllegalStateException_if_layer_is_closed() {
+    public void should_throw_IllegalStateException_if_layer_is_closed() throws Exception {
+        // Given
+        Files.createDirectories(stagingDir);
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         layer.close();
+
+        // When / Then
         assertThatThrownBy(() -> layer.createDirectory("path/to/directory"))
             .isInstanceOf(IllegalStateException.class)
             .hasMessage("Layer is closed, but must be open for this operation");
     }
 
     @Test
-    public void should_throw_IllegalArgumentException_if_path_is_null() {
+    public void should_throw_IllegalArgumentException_if_path_is_null() throws Exception {
+        // Given
+        Files.createDirectories(stagingDir);
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
+
+        // When / Then
         assertThatThrownBy(() -> layer.createDirectory(null))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("Path cannot be null");
     }
 
     @Test
-    public void should_throw_IllegalArgumentException_if_path_is_blank() {
+    public void should_throw_IllegalArgumentException_if_path_is_blank() throws Exception {
+        // Given
+        Files.createDirectories(stagingDir);
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
+
+        // When / Then
         assertThatThrownBy(() -> layer.createDirectory(" "))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("Path cannot be blank");
     }
 
     @Test
-    public void should_create_staging_dir_if_path_is_empty() throws Exception {
+    public void should_throw_IllegalArgumentException_if_path_is_outside_staging_dir() throws Exception {
+        // Given
+        Files.createDirectories(stagingDir);
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
-        layer.createDirectory("");
-        assertThat(stagingDir).exists();
-    }
 
-    @Test
-    public void should_throw_IllegalArgumentException_if_path_is_not_a_valid_path() {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
+        // When / Then
         assertThatThrownBy(() -> layer.createDirectory("path/to/../../../directory"))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("Path is outside staging directory");

--- a/src/test/java/nl/knaw/dans/layerstore/LayerDeleteDirectoryTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerDeleteDirectoryTest.java
@@ -17,6 +17,8 @@ package nl.knaw.dans.layerstore;
 
 import org.junit.jupiter.api.Test;
 
+import java.nio.file.Files;
+
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
@@ -54,8 +56,9 @@ public class LayerDeleteDirectoryTest extends AbstractTestWithTestDir {
     }
 
     @Test
-    public void should_throw_IllegalArgumentException_when_path_is_null() {
+    public void should_throw_IllegalArgumentException_when_path_is_null() throws Exception {
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
+        Files.createDirectories(stagingDir);
         assertThatThrownBy(() -> layer.deleteDirectory(null))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("Path cannot be null");

--- a/src/test/java/nl/knaw/dans/layerstore/LayerDeleteDirectoryTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerDeleteDirectoryTest.java
@@ -25,13 +25,16 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 public class LayerDeleteDirectoryTest extends AbstractTestWithTestDir {
     @Test
     public void should_delete_directory_in_staging_dir_when_layer_is_open() throws Exception {
+        // Given
+        Files.createDirectories(stagingDir);
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         createEmptyStagingDirFiles("path/to/file1", "path/to/file2");
         createEmptyStagingDirFiles("path/too/file1", "path/too/file2");
 
-        // Delete the files in the first directory
+        // When
         layer.deleteDirectory("path/to");
 
+        // Then
         // Check that the files in the first directory are gone
         assertThat(stagingDir.resolve("path/to")).doesNotExist();
 
@@ -43,13 +46,15 @@ public class LayerDeleteDirectoryTest extends AbstractTestWithTestDir {
     }
 
     @Test
-    public void should_throw_IllegalStateException_when_layer_is_closed() {
+    public void should_throw_IllegalStateException_when_layer_is_closed() throws Exception {
+        // Given
+        Files.createDirectories(stagingDir);
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
-        // Create directories with files in it
         createEmptyStagingDirFiles("path/to/file1", "path/to/file2");
         createEmptyStagingDirFiles("path/too/file1", "path/too/file2");
         layer.close();
 
+        // When / Then
         assertThatThrownBy(() -> layer.deleteDirectory("path/to"))
             .isInstanceOf(IllegalStateException.class)
             .hasMessage("Layer is closed, but must be open for this operation");
@@ -57,8 +62,11 @@ public class LayerDeleteDirectoryTest extends AbstractTestWithTestDir {
 
     @Test
     public void should_throw_IllegalArgumentException_when_path_is_null() throws Exception {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
+        // Given
         Files.createDirectories(stagingDir);
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
+
+        // When / Then
         assertThatThrownBy(() -> layer.deleteDirectory(null))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("Path cannot be null");

--- a/src/test/java/nl/knaw/dans/layerstore/LayerDeleteFilesTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerDeleteFilesTest.java
@@ -27,19 +27,27 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 public class LayerDeleteFilesTest extends AbstractTestWithTestDir {
     @Test
     public void should_delete_files_in_staging_dir_if_layer_is_open() throws Exception {
+        // Given
+        Files.createDirectories(stagingDir);
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         createEmptyStagingDirFiles("path/to/file1", "path/to/file2");
 
+        // When
         layer.deleteFiles(List.of("path/to/file1", "path/to/file2"));
+
+        // Then
         assertThat(stagingDir.resolve("path/to/file1")).doesNotExist();
         assertThat(stagingDir.resolve("path/to/file2")).doesNotExist();
     }
 
     @Test
     public void should_throw_IllegalStateException_if_layer_is_closed() throws Exception {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
+        // Given
         Files.createDirectories(stagingDir);
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         layer.close();
+
+        // When / Then
         assertThatThrownBy(() -> layer.deleteFiles(List.of("path/to/file1", "path/to/file2")))
             .isInstanceOf(IllegalStateException.class)
             .hasMessage("Layer is closed, but must be open for this operation");
@@ -47,8 +55,11 @@ public class LayerDeleteFilesTest extends AbstractTestWithTestDir {
 
     @Test
     public void should_throw_IllegalArgumentException_if_path_is_null() throws Exception {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
+        // Given
         Files.createDirectories(stagingDir);
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
+
+        // When / Then
         assertThatThrownBy(() -> layer.deleteFiles(null))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("Paths cannot be null");
@@ -56,6 +67,8 @@ public class LayerDeleteFilesTest extends AbstractTestWithTestDir {
 
     @Test
     public void should_throw_IllegalArgumentException_if_path_contains_null() throws Exception {
+        // Given
+        Files.createDirectories(stagingDir);
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
 
         if (!stagingDir.resolve("path/to").toFile().mkdirs() ||
@@ -66,6 +79,7 @@ public class LayerDeleteFilesTest extends AbstractTestWithTestDir {
         paths.add("path/to/file1");
         paths.add(null);
 
+        // When / Then
         assertThatThrownBy(() -> layer.deleteFiles(paths))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("Path cannot be null");

--- a/src/test/java/nl/knaw/dans/layerstore/LayerDeleteFilesTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerDeleteFilesTest.java
@@ -17,6 +17,7 @@ package nl.knaw.dans.layerstore;
 
 import org.junit.jupiter.api.Test;
 
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -35,8 +36,9 @@ public class LayerDeleteFilesTest extends AbstractTestWithTestDir {
     }
 
     @Test
-    public void should_throw_IllegalStateException_if_layer_is_closed() {
+    public void should_throw_IllegalStateException_if_layer_is_closed() throws Exception {
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
+        Files.createDirectories(stagingDir);
         layer.close();
         assertThatThrownBy(() -> layer.deleteFiles(List.of("path/to/file1", "path/to/file2")))
             .isInstanceOf(IllegalStateException.class)
@@ -44,8 +46,9 @@ public class LayerDeleteFilesTest extends AbstractTestWithTestDir {
     }
 
     @Test
-    public void should_throw_IllegalArgumentException_if_path_is_null() {
+    public void should_throw_IllegalArgumentException_if_path_is_null() throws Exception {
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
+        Files.createDirectories(stagingDir);
         assertThatThrownBy(() -> layer.deleteFiles(null))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("Paths cannot be null");

--- a/src/test/java/nl/knaw/dans/layerstore/LayerGetSizeInBytesTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerGetSizeInBytesTest.java
@@ -17,6 +17,8 @@ package nl.knaw.dans.layerstore;
 
 import org.junit.jupiter.api.Test;
 
+import java.nio.file.Files;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
@@ -27,6 +29,7 @@ public class LayerGetSizeInBytesTest extends AbstractTestWithTestDir {
     @Test
     public void should_add_up_file_sizes() throws Exception {
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
+        Files.createDirectories(stagingDir);
         layer.writeFile("test.txt", toInputStream("Hello world!", UTF_8));
         layer.createDirectory("path/to");
         layer.writeFile("path/to/other.txt", toInputStream("Whatever", UTF_8));
@@ -35,8 +38,9 @@ public class LayerGetSizeInBytesTest extends AbstractTestWithTestDir {
     }
 
     @Test
-    public void should_throw_IllegalStateException_when_layer_is_closed() {
+    public void should_throw_IllegalStateException_when_layer_is_closed() throws Exception {
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
+        Files.createDirectories(stagingDir);
         layer.close();
 
         assertThatThrownBy(layer::getSizeInBytes).

--- a/src/test/java/nl/knaw/dans/layerstore/LayerManagerConstructorTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerManagerConstructorTest.java
@@ -27,10 +27,14 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 public class LayerManagerConstructorTest extends AbstractLayerDatabaseTest {
 
     @Test
-    public void should_create_the_staging_root() throws IOException {
+    public void should_create_the_staging_root_and_top_layer() throws IOException {
         assertThat(stagingDir).doesNotExist();
-        new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
-        assertThat(stagingDir).isEmptyDirectory();
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
+        assertThat(stagingDir).exists();
+        try (var stream = Files.list(stagingDir)) {
+            assertThat(stream).hasSize(1);
+        }
+        assertThat(layerManager.getTopLayer().getId()).isGreaterThan(0);
     }
 
     @Test

--- a/src/test/java/nl/knaw/dans/layerstore/LayerManagerConstructorTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerManagerConstructorTest.java
@@ -29,7 +29,7 @@ public class LayerManagerConstructorTest extends AbstractLayerDatabaseTest {
     @Test
     public void should_create_the_staging_root() throws IOException {
         assertThat(stagingDir).doesNotExist();
-        new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         assertThat(stagingDir).isEmptyDirectory();
     }
 
@@ -38,7 +38,7 @@ public class LayerManagerConstructorTest extends AbstractLayerDatabaseTest {
         var existingLayerId = 1234567890123L;
         Files.createDirectories(stagingDir.resolve(String.valueOf(existingLayerId)));
 
-        var topLayerId = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService())
+        var topLayerId = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver())
             .getTopLayer().getId();
         assertThat(topLayerId).isEqualTo(existingLayerId);
     }
@@ -49,7 +49,7 @@ public class LayerManagerConstructorTest extends AbstractLayerDatabaseTest {
         var invalidFileBetweenLayerDirs = "1234567890123";
         Files.createFile(stagingDir.resolve(invalidFileBetweenLayerDirs));
 
-        assertThatThrownBy(() -> new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService()))
+        assertThatThrownBy(() -> new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver()))
             .isInstanceOf(IllegalStateException.class)
             .hasMessage("Not a directory: target/test/LayerManagerConstructorTest/layer_staging/" + invalidFileBetweenLayerDirs);
     }
@@ -59,7 +59,7 @@ public class LayerManagerConstructorTest extends AbstractLayerDatabaseTest {
         var existingLayerDir = "123456789012";
         Files.createDirectories(stagingDir.resolve(existingLayerDir));
 
-        assertThatThrownBy(() -> new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService()))
+        assertThatThrownBy(() -> new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver()))
             .isInstanceOf(IllegalStateException.class)
             .hasMessage("Not a timestamp: target/test/LayerManagerConstructorTest/layer_staging/" + existingLayerDir);
     }
@@ -69,7 +69,7 @@ public class LayerManagerConstructorTest extends AbstractLayerDatabaseTest {
         var invalidDirBetweenLayerDirs = "abcdefghijklmnopqrstuvwxyz";
         Files.createDirectories(stagingDir.resolve(invalidDirBetweenLayerDirs));
 
-        assertThatThrownBy(() -> new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService()))
+        assertThatThrownBy(() -> new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver()))
             .isInstanceOf(IllegalStateException.class)
             .hasMessage("Not a timestamp: target/test/LayerManagerConstructorTest/layer_staging/" + invalidDirBetweenLayerDirs);
     }
@@ -79,7 +79,7 @@ public class LayerManagerConstructorTest extends AbstractLayerDatabaseTest {
         var invalidDirBetweenLayerDirs = "1.2";
         Files.createDirectories(stagingDir.resolve(invalidDirBetweenLayerDirs));
 
-        assertThatThrownBy(() -> new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService()))
+        assertThatThrownBy(() -> new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver()))
             .isInstanceOf(IllegalStateException.class)
             .hasMessage("Not a timestamp: target/test/LayerManagerConstructorTest/layer_staging/" + invalidDirBetweenLayerDirs);
     }

--- a/src/test/java/nl/knaw/dans/layerstore/LayerManagerConstructorTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerManagerConstructorTest.java
@@ -27,14 +27,14 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 public class LayerManagerConstructorTest extends AbstractLayerDatabaseTest {
 
     @Test
-    public void should_create_the_staging_root_and_top_layer() throws IOException {
+    public void should_create_empty_staging_root() throws IOException {
         assertThat(stagingDir).doesNotExist();
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         assertThat(stagingDir).exists();
         try (var stream = Files.list(stagingDir)) {
-            assertThat(stream).hasSize(1);
+            assertThat(stream).isEmpty();
         }
-        assertThat(layerManager.getTopLayer().getId()).isGreaterThan(0);
+        assertThat(layerManager.getTopLayer()).isNull();
     }
 
     @Test

--- a/src/test/java/nl/knaw/dans/layerstore/LayerManagerGetLayerTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerManagerGetLayerTest.java
@@ -15,7 +15,6 @@
  */
 package nl.knaw.dans.layerstore;
 
-import io.dropwizard.util.DirectExecutorService;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -34,7 +33,7 @@ public class LayerManagerGetLayerTest extends AbstractTestWithTestDir {
     @Test
     public void should_throw_when_layer_id_does_not_exist() throws IOException {
         // Given
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
 
         // When
         assertThatThrownBy(() -> layerManager.getLayer(1234567890123L))
@@ -47,7 +46,7 @@ public class LayerManagerGetLayerTest extends AbstractTestWithTestDir {
     @Test
     public void should_find_garbage_in_stagingDir_created_after_creating_LayerManagerImpl_object() throws IOException {
         // Given
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         Files.createDirectories(stagingDir.resolve("0"));
 
         //When
@@ -60,7 +59,7 @@ public class LayerManagerGetLayerTest extends AbstractTestWithTestDir {
     @Test
     public void should_find_a_top_layer_with_content() throws IOException {
         // Given
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var topLayer = layerManager.getTopLayer();
         topLayer.writeFile("test.txt", toInputStream("Hello world!", UTF_8));
 
@@ -74,7 +73,7 @@ public class LayerManagerGetLayerTest extends AbstractTestWithTestDir {
     @Test
     public void should_find_an_empty_top_layer() throws IOException {
         // Given
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         long topLayerId = layerManager.getTopLayer().getId();
         assertThat(stagingDir.resolve(String.valueOf(topLayerId))).doesNotExist();
 
@@ -89,7 +88,7 @@ public class LayerManagerGetLayerTest extends AbstractTestWithTestDir {
     public void should_find_an_empty_archived_layer() throws Exception {
         // Given
         Files.createDirectories(archiveDir);
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir));
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var initialLayerId = layerManager.getTopLayer().getId();
         assertThat(stagingDir).isEmptyDirectory(); // no content in the current layer
         assertThat(archiveDir).isEmptyDirectory(); // nothing archived yet
@@ -112,7 +111,7 @@ public class LayerManagerGetLayerTest extends AbstractTestWithTestDir {
     public void should_have_status_archived_for_the_found_layer() throws Exception {
         // Given
         Files.createDirectories(archiveDir);
-        var layerManager = new LayerManagerImpl(stagingDir, new TarArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new TarArchiveProvider(archiveDir), new DirectLayerArchiver());
         layerManager.getTopLayer().writeFile("test.txt", toInputStream("Hello world!", UTF_8));
         Layer initialLayer = layerManager.getTopLayer();
         var initialLayerId = initialLayer.getId();

--- a/src/test/java/nl/knaw/dans/layerstore/LayerManagerGetLayerTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerManagerGetLayerTest.java
@@ -75,7 +75,6 @@ public class LayerManagerGetLayerTest extends AbstractTestWithTestDir {
         // Given
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         long topLayerId = layerManager.getTopLayer().getId();
-        assertThat(stagingDir.resolve(String.valueOf(topLayerId))).doesNotExist();
 
         // When
         var layer = layerManager.getLayer(topLayerId);
@@ -90,20 +89,15 @@ public class LayerManagerGetLayerTest extends AbstractTestWithTestDir {
         Files.createDirectories(archiveDir);
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var initialLayerId = layerManager.getTopLayer().getId();
-        assertThat(stagingDir).isEmptyDirectory(); // no content in the current layer
         assertThat(archiveDir).isEmptyDirectory(); // nothing archived yet
-        sleep(1L); // to make sure to get a layer with another time stamp
-        layerManager.newTopLayer();
-        assertThat(initialLayerId).isNotEqualTo(layerManager.getTopLayer().getId());
-        assertThat(stagingDir).isEmptyDirectory();
-        Thread.sleep(1L); // wait for creation of the zip file, strangely not required when running the test stand alone
-        assertThat(archiveDir).isNotEmptyDirectory();
 
         // When
-        var layer = layerManager.getLayer(initialLayerId);
-        // Then
+        layerManager.newTopLayer();
 
-        assertThat(layer.getId()).isNotEqualTo(layerManager.getTopLayer().getId());
+        // Then
+        assertThat(initialLayerId)
+            .withFailMessage("The initial top layer should have a different id than the new top layer")
+            .isNotEqualTo(layerManager.getTopLayer().getId());
         assertThat(archiveDir).isNotEmptyDirectory();
     }
 

--- a/src/test/java/nl/knaw/dans/layerstore/LayerManagerNewTopLayerTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerManagerNewTopLayerTest.java
@@ -28,8 +28,8 @@ public class LayerManagerNewTopLayerTest extends AbstractCapturingTest {
     // the method under test is also involved in tests for other LayerManagerImpl methods and LayeredItemStore methods
 
     @Test
-    public void should_log_already_archived() throws IOException {
-
+    public void should_throw_on_already_archived() throws IOException {
+        // Given
         var layerManager = new LayerManagerImpl(stagingDir,
             new DmfTarArchiveProvider(
                 getNoopDmfTarRunner(),
@@ -37,8 +37,9 @@ public class LayerManagerNewTopLayerTest extends AbstractCapturingTest {
             ),
             new DirectLayerArchiver()
         );
+        layerManager.newTopLayer(); // Create the first layer
 
-        // Run the method under test
+        // When / Then
         assertThatThrownBy(layerManager::newTopLayer)
             .isInstanceOf(IllegalStateException.class)
             .hasMessage("Layer is already archived");

--- a/src/test/java/nl/knaw/dans/layerstore/LayerManagerNewTopLayerTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerManagerNewTopLayerTest.java
@@ -15,9 +15,6 @@
  */
 package nl.knaw.dans.layerstore;
 
-import ch.qos.logback.classic.Level;
-import io.dropwizard.util.DirectExecutorService;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.validation.constraints.NotNull;
@@ -25,46 +22,26 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 public class LayerManagerNewTopLayerTest extends AbstractCapturingTest {
 
     // the method under test is also involved in tests for other LayerManagerImpl methods and LayeredItemStore methods
-
-    @BeforeEach
-    public void setUp() throws Exception {
-        super.setUp();
-        logged = captureLog(Level.ERROR, "nl.knaw.dans"); // override debug level
-    }
 
     @Test
     public void should_log_already_archived() throws IOException {
 
         var layerManager = new LayerManagerImpl(stagingDir,
             new DmfTarArchiveProvider(
-                getDmfTarRunner(),
+                getNoopDmfTarRunner(),
                 sshRunnerExpectsFileToExist(true)
             ),
-            new DirectExecutorService()
+            new DirectLayerArchiver()
         );
-        var initialTopLayerId = layerManager.getTopLayer().getId();
 
         // Run the method under test
         assertThatThrownBy(layerManager::newTopLayer)
-            .isInstanceOf(RuntimeException.class)
-            .hasMessage("java.lang.IllegalStateException: Layer is already archived");
-
-        // Check the logs
-        var loggingEvent = logged.list.get(0);
-        assertThat(loggingEvent.getLevel()).isEqualTo(Level.ERROR);
-        assertThat(loggingEvent.getFormattedMessage())
-            .isEqualTo("Error archiving layer with id " + initialTopLayerId);
-
-        // Check stdout, different formats when running standalone or in a suite
-        var contentString = stdout.toString();
-        assertThat(contentString).contains("Error archiving layer with id " + initialTopLayerId);
-        assertThat(contentString).contains("java.lang.IllegalStateException: Layer is already archived");
-        assertThat(contentString).contains("at nl.knaw.dans.layerstore.LayerManagerNewTopLayerTest");
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Layer is already archived");
     }
 
     private static @NotNull SshRunner sshRunnerExpectsFileToExist(boolean exists) {
@@ -77,7 +54,7 @@ public class LayerManagerNewTopLayerTest extends AbstractCapturingTest {
         };
     }
 
-    private static @NotNull DmfTarRunner getDmfTarRunner() {
+    private static @NotNull DmfTarRunner getNoopDmfTarRunner() {
         return new DmfTarRunner(Path.of("dmftar"), "testuser", "dummyhost", Path.of("testarchive")) {
 
             @Override

--- a/src/test/java/nl/knaw/dans/layerstore/LayerMoveDirectoryInternalTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerMoveDirectoryInternalTest.java
@@ -53,8 +53,8 @@ public class LayerMoveDirectoryInternalTest extends AbstractTestWithTestDir {
 
     @Test
     public void should_throw_IllegalArgumentException_if_source_is_outside_staging_dir() throws Exception {
-        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         Files.createDirectories(stagingDir);
+        var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
         assertThatThrownBy(() -> layer.moveDirectoryInternal("../path/to/", "path/too/"))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("Path is outside staging directory");

--- a/src/test/java/nl/knaw/dans/layerstore/LayerMoveDirectoryInternalTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerMoveDirectoryInternalTest.java
@@ -17,6 +17,8 @@ package nl.knaw.dans.layerstore;
 
 import org.junit.jupiter.api.Test;
 
+import java.nio.file.Files;
+
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
@@ -50,16 +52,18 @@ public class LayerMoveDirectoryInternalTest extends AbstractTestWithTestDir {
     }
 
     @Test
-    public void should_throw_IllegalArgumentException_if_source_is_outside_staging_dir() {
+    public void should_throw_IllegalArgumentException_if_source_is_outside_staging_dir() throws Exception {
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
+        Files.createDirectories(stagingDir);
         assertThatThrownBy(() -> layer.moveDirectoryInternal("../path/to/", "path/too/"))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("Path is outside staging directory");
     }
 
     @Test
-    public void should_throw_IllegalArgumentException_if_destination_is_outside_staging_dir() {
+    public void should_throw_IllegalArgumentException_if_destination_is_outside_staging_dir() throws Exception {
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
+        Files.createDirectories(stagingDir);
         assertThatThrownBy(() -> layer.moveDirectoryInternal("path/to/", "../path/too/"))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("Path is outside staging directory");

--- a/src/test/java/nl/knaw/dans/layerstore/LayerReopenTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerReopenTest.java
@@ -29,8 +29,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class LayerReopenTest extends AbstractTestWithTestDir {
 
     @Test
-    public void should_throw_not_archived() {
+    public void should_throw_not_archived() throws Exception {
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
+        Files.createDirectories(stagingDir);
         assertTrue(layer.isOpen());
         layer.close();
         assertFalse(layer.isOpen());
@@ -40,8 +41,9 @@ public class LayerReopenTest extends AbstractTestWithTestDir {
     }
 
     @Test
-    public void should_throw_must_be_closed() {
+    public void should_throw_must_be_closed() throws Exception {
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
+        Files.createDirectories(stagingDir);
         assertThatThrownBy(layer::reopen).
             isInstanceOf(IllegalStateException.class)
             .hasMessage("Layer is open, but must be closed for this operation");

--- a/src/test/java/nl/knaw/dans/layerstore/LayerWriteFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerWriteFileTest.java
@@ -18,6 +18,7 @@ package nl.knaw.dans.layerstore;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.commons.io.IOUtils.toInputStream;
@@ -28,6 +29,7 @@ public class LayerWriteFileTest extends AbstractTestWithTestDir {
     @Test
     public void should_write_file_to_staging_dir_when_layer_is_open() throws Exception {
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
+        Files.createDirectories(stagingDir);
 
         // Write a file to the layer
         var testContent = "Hello world!";
@@ -39,8 +41,9 @@ public class LayerWriteFileTest extends AbstractTestWithTestDir {
     }
 
     @Test
-    public void should_throw_IllegalStateException_when_layer_is_closed() {
+    public void should_throw_IllegalStateException_when_layer_is_closed() throws Exception {
         var layer = new LayerImpl(1, stagingDir, new ZipArchive(archiveDir.resolve("test.zip")));
+        Files.createDirectories(stagingDir);
         layer.close();
 
         assertThatThrownBy(() -> layer.writeFile("whatever.txt", toInputStream("whatever", UTF_8))).

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreCheckLayerIdsTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreCheckLayerIdsTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.layerstore;
+
+import io.dropwizard.util.DirectExecutorService;
+import nl.knaw.dans.layerstore.Item.Type;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.io.IOUtils.toInputStream;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class LayeredItemStoreCheckLayerIdsTest extends AbstractLayerDatabaseTest {
+
+    @Test
+    public void should_pass_if_store_and_database_are_empty() throws Exception {
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layeredStore = new LayeredItemStore(db, layerManager);
+        Files.createDirectories(archiveDir);
+        assertThatCode(layeredStore::checkSameLayerIdsFoundOnStorageAsInDatabase).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void should_pass_if_store_and_database_are_in_sync() throws Exception {
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layeredStore = new LayeredItemStore(db, layerManager);
+        Files.createDirectories(archiveDir);
+        layeredStore.createDirectory("a/b/c/d");
+        layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!", UTF_8));
+        layeredStore.writeFile("a/b/c/test2.txt", toInputStream("Hello again!", UTF_8));
+        assertThatCode(layeredStore::checkSameLayerIdsFoundOnStorageAsInDatabase).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void should_fail_if_db_contains_layer_not_found_on_storage() throws Exception {
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layeredStore = new LayeredItemStore(db, layerManager);
+        Files.createDirectories(archiveDir);
+        layeredStore.createDirectory("a/b/c/d");
+        layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!", UTF_8));
+        layeredStore.writeFile("a/b/c/test2.txt", toInputStream("Hello again!", UTF_8));
+        // Simulate a manual change in the database that is not reflected in the store
+        var nonExistentLayerId = layerManager.getTopLayer().getId() + 1;
+        daoTestExtension.inTransaction(() -> {
+            var itemRecord = ItemRecord.builder()
+                .path("a/b/c/d/test1.txt")
+                .type(Type.File)
+                .layerId(nonExistentLayerId)
+                .build();
+            db.saveRecords(itemRecord);
+        });
+        // Expect an IllegalStateException to be thrown
+        assertThatThrownBy(layeredStore::checkSameLayerIdsFoundOnStorageAsInDatabase).isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("Layer IDs are inconsistent between database and storage. Missing on storage: [" + nonExistentLayerId + "]");
+    }
+
+    @Test
+    public void should_fail_if_staging_dir_contains_layer_not_found_in_db() throws Exception {
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layeredStore = new LayeredItemStore(db, layerManager);
+        Files.createDirectories(archiveDir);
+        layeredStore.createDirectory("a/b/c/d");
+        layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!", UTF_8));
+        layeredStore.writeFile("a/b/c/test2.txt", toInputStream("Hello again!", UTF_8));
+        // Simulate a manual change in the store that is not reflected in the database
+        var nonExistentLayerId = layerManager.getTopLayer().getId() + 1;
+        var newStagingDir = stagingDir.resolve(Long.toString(nonExistentLayerId));
+        Files.createDirectories(newStagingDir);
+        assertThatThrownBy(layeredStore::checkSameLayerIdsFoundOnStorageAsInDatabase).isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("Layer IDs are inconsistent between database and storage. Missing in database: [" + nonExistentLayerId + "]");
+    }
+
+    @Test
+    public void should_fail_if_archive_dir_contains_layer_not_found_in_db() throws Exception {
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layeredStore = new LayeredItemStore(db, layerManager);
+        Files.createDirectories(archiveDir);
+        layeredStore.createDirectory("a/b/c/d");
+        layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!", UTF_8));
+        layeredStore.writeFile("a/b/c/test2.txt", toInputStream("Hello again!", UTF_8));
+        // Simulate a manual change in the store that is not reflected in the database
+        var nonExistentLayerId = layerManager.getTopLayer().getId() + 1;
+        var newArchivedLayer = archiveDir.resolve(Long.toString(nonExistentLayerId) + ".zip");
+        Files.createFile(newArchivedLayer);
+        assertThatThrownBy(layeredStore::checkSameLayerIdsFoundOnStorageAsInDatabase).isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("Layer IDs are inconsistent between database and storage. Missing in database: [" + nonExistentLayerId + "]");
+    }
+
+    @Test
+    public void should_pass_if_multiple_layers_present_and_store_in_sync_with_db() throws Exception {
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layeredStore = new LayeredItemStore(db, layerManager);
+        Files.createDirectories(archiveDir);
+        layeredStore.createDirectory("a/b/c/d");
+        layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!", UTF_8));
+        layeredStore.writeFile("a/b/c/test2.txt", toInputStream("Hello again!", UTF_8));
+        layerManager.newTopLayer();
+        layeredStore.createDirectory("x/y/z");
+        layeredStore.writeFile("x/y/z/file1.txt", toInputStream("Layer 2 file", UTF_8));
+        layerManager.newTopLayer();
+        layeredStore.createDirectory("m/n");
+        layeredStore.writeFile("m/n/file2.txt", toInputStream("Layer 3 file", UTF_8));
+        assertThatCode(layeredStore::checkSameLayerIdsFoundOnStorageAsInDatabase).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void should_fail_and_report_all_inconsistencies() throws Exception {
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layeredStore = new LayeredItemStore(db, layerManager);
+        Files.createDirectories(archiveDir);
+        layeredStore.createDirectory("a/b/c/d");
+        layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!", UTF_8));
+        layeredStore.writeFile("a/b/c/test2.txt", toInputStream("Hello again!", UTF_8));
+        // Simulate a manual change in the database that is not reflected in the store
+        var nonExistentLayerIdInStore1 = layerManager.getTopLayer().getId() + 1;
+        var nonExistentLayerIdInStore2 = layerManager.getTopLayer().getId() + 2;
+        daoTestExtension.inTransaction(() -> {
+            var itemRecord1 = ItemRecord.builder()
+                .path("a/b/c/d/test1.txt")
+                .type(Type.File)
+                .layerId(nonExistentLayerIdInStore1)
+                .build();
+            var itemRecord2 = ItemRecord.builder()
+                .path("a/b/c/test2.txt")
+                .type(Type.File)
+                .layerId(nonExistentLayerIdInStore2)
+                .build();
+            db.saveRecords(itemRecord1, itemRecord2);
+        });
+        // Simulate a manual change in the store that is not reflected in the database
+        var nonExistentLayerIdInDb1 = layerManager.getTopLayer().getId() + 3;
+        var nonExistentLayerIdInDb2 = layerManager.getTopLayer().getId() + 4;
+        var newStagingDir = stagingDir.resolve(Long.toString(nonExistentLayerIdInDb1));
+        Files.createDirectories(newStagingDir);
+        var newArchivedLayer = archiveDir.resolve(Long.toString(nonExistentLayerIdInDb2) + ".zip");
+        Files.createFile(newArchivedLayer);
+        // Expect an IllegalStateException to be thrown
+        assertThatThrownBy(layeredStore::checkSameLayerIdsFoundOnStorageAsInDatabase).isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("Layer IDs are inconsistent between database and storage. Missing in database: [" + nonExistentLayerIdInDb1 + ", "
+                + nonExistentLayerIdInDb2 + "] Missing on storage: [" + nonExistentLayerIdInStore1 + ", " + nonExistentLayerIdInStore2 + "]");
+
+    }
+}

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreCheckSameLayerIdsFoundOnStorageAsInDatabaseTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreCheckSameLayerIdsFoundOnStorageAsInDatabaseTest.java
@@ -26,11 +26,11 @@ import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class LayeredItemStoreCheckLayerIdsTest extends AbstractLayerDatabaseTest {
+public class LayeredItemStoreCheckSameLayerIdsFoundOnStorageAsInDatabaseTest extends AbstractLayerDatabaseTest {
 
     @Test
     public void should_pass_if_store_and_database_are_empty() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
         Files.createDirectories(archiveDir);
         assertThatCode(layeredStore::checkSameLayerIdsFoundOnStorageAsInDatabase).doesNotThrowAnyException();
@@ -38,7 +38,7 @@ public class LayeredItemStoreCheckLayerIdsTest extends AbstractLayerDatabaseTest
 
     @Test
     public void should_pass_if_store_and_database_are_in_sync() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
         Files.createDirectories(archiveDir);
         layeredStore.createDirectory("a/b/c/d");
@@ -49,7 +49,7 @@ public class LayeredItemStoreCheckLayerIdsTest extends AbstractLayerDatabaseTest
 
     @Test
     public void should_fail_if_db_contains_layer_not_found_on_storage() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
         Files.createDirectories(archiveDir);
         layeredStore.createDirectory("a/b/c/d");
@@ -72,7 +72,7 @@ public class LayeredItemStoreCheckLayerIdsTest extends AbstractLayerDatabaseTest
 
     @Test
     public void should_fail_if_staging_dir_contains_layer_not_found_in_db() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
         Files.createDirectories(archiveDir);
         layeredStore.createDirectory("a/b/c/d");
@@ -88,7 +88,7 @@ public class LayeredItemStoreCheckLayerIdsTest extends AbstractLayerDatabaseTest
 
     @Test
     public void should_fail_if_archive_dir_contains_layer_not_found_in_db() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
         Files.createDirectories(archiveDir);
         layeredStore.createDirectory("a/b/c/d");
@@ -104,7 +104,7 @@ public class LayeredItemStoreCheckLayerIdsTest extends AbstractLayerDatabaseTest
 
     @Test
     public void should_pass_if_multiple_layers_present_and_store_in_sync_with_db() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
         Files.createDirectories(archiveDir);
         layeredStore.createDirectory("a/b/c/d");
@@ -121,7 +121,7 @@ public class LayeredItemStoreCheckLayerIdsTest extends AbstractLayerDatabaseTest
 
     @Test
     public void should_fail_and_report_all_inconsistencies() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
         Files.createDirectories(archiveDir);
         layeredStore.createDirectory("a/b/c/d");

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreCheckSameLayersOnStorageAndDbTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreCheckSameLayersOnStorageAndDbTest.java
@@ -44,6 +44,7 @@ public class LayeredItemStoreCheckSameLayersOnStorageAndDbTest extends AbstractL
         Files.createDirectories(archiveDir);
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredItemStore = new LayeredItemStore(db, layerManager);
+        layerManager.newTopLayer();
         var anotherInstance = new LayeredItemStore(db, layerManager);
 
         layeredItemStore.createDirectory("a/b/c/d");
@@ -60,6 +61,7 @@ public class LayeredItemStoreCheckSameLayersOnStorageAndDbTest extends AbstractL
         Files.createDirectories(archiveDir);
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredItemStore = new LayeredItemStore(db, layerManager);
+        layeredItemStore.newTopLayer();
         var checker = new LayeredItemStore(db, layerManager);
 
         layeredItemStore.createDirectory("a/b/c/d");
@@ -87,6 +89,7 @@ public class LayeredItemStoreCheckSameLayersOnStorageAndDbTest extends AbstractL
         Files.createDirectories(archiveDir);
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredItemStore = new LayeredItemStore(db, layerManager);
+        layeredItemStore.newTopLayer();
         var checker = new LayeredItemStore(db, layerManager);
 
         layeredItemStore.createDirectory("a/b/c/d");
@@ -108,6 +111,7 @@ public class LayeredItemStoreCheckSameLayersOnStorageAndDbTest extends AbstractL
         Files.createDirectories(archiveDir);
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredItemStore = new LayeredItemStore(db, layerManager);
+        layeredItemStore.newTopLayer();
         var checker = new LayeredItemStore(db, layerManager);
 
         layeredItemStore.createDirectory("a/b/c/d");
@@ -129,6 +133,7 @@ public class LayeredItemStoreCheckSameLayersOnStorageAndDbTest extends AbstractL
         Files.createDirectories(archiveDir);
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredItemStore = new LayeredItemStore(db, layerManager);
+        layerManager.newTopLayer();
         var checker = new LayeredItemStore(db, layerManager);
 
         layeredItemStore.createDirectory("a/b/c/d");
@@ -151,6 +156,7 @@ public class LayeredItemStoreCheckSameLayersOnStorageAndDbTest extends AbstractL
         Files.createDirectories(archiveDir);
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredItemStore = new LayeredItemStore(db, layerManager);
+        layerManager.newTopLayer();
         var checker = new LayeredItemStore(db, layerManager);
 
         layeredItemStore.createDirectory("a/b/c/d");

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreCopyDirectoryOutOfTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreCopyDirectoryOutOfTest.java
@@ -37,7 +37,7 @@ public class LayeredItemStoreCopyDirectoryOutOfTest extends AbstractLayerDatabas
 
     @Test
     public void should_copy_an_empty_child_directory() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
         Files.createDirectories(archiveDir);
         layeredStore.createDirectory("a/b/c/d/e");
@@ -53,7 +53,7 @@ public class LayeredItemStoreCopyDirectoryOutOfTest extends AbstractLayerDatabas
     @Test
     public void should_overwrite_existing_files() throws Exception {
         // As in https://github.com/OCFL/ocfl-java/blob/a4d4f17149640132bdfd9c00a170f414e1c7cf33/ocfl-java-core/src/main/java/io/ocfl/core/storage/filesystem/FileSystemStorage.java#L226C1-L243C6
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
         Files.createDirectories(archiveDir);
         layeredStore.createDirectory("a/b/c/d/e");
@@ -69,7 +69,7 @@ public class LayeredItemStoreCopyDirectoryOutOfTest extends AbstractLayerDatabas
 
     @Test
     public void should_not_copy_an_empty_source_directory() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
         Files.createDirectories(archiveDir);
         layeredStore.createDirectory("a/b/c/d/e");
@@ -84,7 +84,7 @@ public class LayeredItemStoreCopyDirectoryOutOfTest extends AbstractLayerDatabas
 
     @Test
     public void should_copy_the_files_of_a_source_which_has_no_child_directories() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
         Files.createDirectories(archiveDir);
         layeredStore.createDirectory("a/b/c/d");

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreCopyDirectoryOutOfTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreCopyDirectoryOutOfTest.java
@@ -15,7 +15,6 @@
  */
 package nl.knaw.dans.layerstore;
 
-import io.dropwizard.util.DirectExecutorService;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,12 +30,15 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 public class LayeredItemStoreCopyDirectoryOutOfTest extends AbstractLayerDatabaseTest {
 
     @BeforeEach
-    public void prepare() throws Exception {
+    public void setUp() throws Exception {
+        super.setUp();
+        Files.createDirectories(archiveDir);
         Files.createDirectories(stagingDir);
     }
 
     @Test
     public void should_copy_an_empty_child_directory() throws Exception {
+        // Given
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
         Files.createDirectories(archiveDir);
@@ -45,14 +47,16 @@ public class LayeredItemStoreCopyDirectoryOutOfTest extends AbstractLayerDatabas
         layeredStore.writeFile("a/b/c/test2.txt", toInputStream("Hello again!", UTF_8));
         var destination = testDir.resolve("copy");
 
+        // When
         layeredStore.copyDirectoryOutOf("a/b/c/d", destination);
 
+        // Then
         assertThat(destination.resolve("a/b/c/d/e")).isEmptyDirectory();
     }
 
     @Test
     public void should_overwrite_existing_files() throws Exception {
-        // As in https://github.com/OCFL/ocfl-java/blob/a4d4f17149640132bdfd9c00a170f414e1c7cf33/ocfl-java-core/src/main/java/io/ocfl/core/storage/filesystem/FileSystemStorage.java#L226C1-L243C6
+        // Given
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
         Files.createDirectories(archiveDir);
@@ -62,13 +66,16 @@ public class LayeredItemStoreCopyDirectoryOutOfTest extends AbstractLayerDatabas
         var destination = testDir.resolve("copy");
         FileUtils.writeLines(destination.resolve("a/b/c/d/test1.txt").toFile(), List.of("Hello there!"));
 
+        // When
         layeredStore.copyDirectoryOutOf("a/b/c/d", destination);
 
+        // Then
         assertThat(destination.resolve("a/b/c/d/test1.txt")).hasContent("Hello world!");
     }
 
     @Test
     public void should_not_copy_an_empty_source_directory() throws Exception {
+        // Given
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
         Files.createDirectories(archiveDir);
@@ -77,13 +84,16 @@ public class LayeredItemStoreCopyDirectoryOutOfTest extends AbstractLayerDatabas
         layeredStore.writeFile("a/b/c/test2.txt", toInputStream("Hello again!", UTF_8));
         Path destination = testDir.resolve("copy");
 
+        // When
         layeredStore.copyDirectoryOutOf("a/b/c/d/e", destination);
 
+        // Then
         assertThat(destination).doesNotExist();
     }
 
     @Test
     public void should_copy_the_files_of_a_source_which_has_no_child_directories() throws Exception {
+        // Given
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
         Files.createDirectories(archiveDir);
@@ -93,8 +103,10 @@ public class LayeredItemStoreCopyDirectoryOutOfTest extends AbstractLayerDatabas
         layeredStore.writeFile("a/b/c/test3.txt", toInputStream("Hello again!", UTF_8));
         Path destination = testDir.resolve("copy");
 
+        // When
         layeredStore.copyDirectoryOutOf("a/b/c/d", destination);
 
+        // Then
         assertThat(destination.resolve("a/b/c/d/test1.txt")).exists();
         assertThat(destination.resolve("a/b/c/d/test2.txt")).exists();
     }

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreCopyDirectoryOutOfTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreCopyDirectoryOutOfTest.java
@@ -41,7 +41,7 @@ public class LayeredItemStoreCopyDirectoryOutOfTest extends AbstractLayerDatabas
         // Given
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
-        Files.createDirectories(archiveDir);
+        layeredStore.newTopLayer();
         layeredStore.createDirectory("a/b/c/d/e");
         layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!", UTF_8));
         layeredStore.writeFile("a/b/c/test2.txt", toInputStream("Hello again!", UTF_8));
@@ -59,7 +59,7 @@ public class LayeredItemStoreCopyDirectoryOutOfTest extends AbstractLayerDatabas
         // Given
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
-        Files.createDirectories(archiveDir);
+        layeredStore.newTopLayer();
         layeredStore.createDirectory("a/b/c/d/e");
         layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!", UTF_8));
         layeredStore.writeFile("a/b/c/test2.txt", toInputStream("Hello again!", UTF_8));
@@ -78,7 +78,7 @@ public class LayeredItemStoreCopyDirectoryOutOfTest extends AbstractLayerDatabas
         // Given
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
-        Files.createDirectories(archiveDir);
+        layeredStore.newTopLayer();
         layeredStore.createDirectory("a/b/c/d/e");
         layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!", UTF_8));
         layeredStore.writeFile("a/b/c/test2.txt", toInputStream("Hello again!", UTF_8));
@@ -96,7 +96,7 @@ public class LayeredItemStoreCopyDirectoryOutOfTest extends AbstractLayerDatabas
         // Given
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
-        Files.createDirectories(archiveDir);
+        layeredStore.newTopLayer();
         layeredStore.createDirectory("a/b/c/d");
         layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!", UTF_8));
         layeredStore.writeFile("a/b/c/d/test2.txt", toInputStream("Hello world!", UTF_8));

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreDeleteDirectoryTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreDeleteDirectoryTest.java
@@ -33,15 +33,16 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 public class LayeredItemStoreDeleteDirectoryTest extends AbstractLayerDatabaseTest {
 
     @BeforeEach
-    public void prepare() throws Exception {
+    public void setUp() throws Exception {
+        super.setUp();
         Files.createDirectories(stagingDir);
+        Files.createDirectories(archiveDir);
     }
 
     @Test
     public void should_not_delete_a_directory_with_content_in_another_layer() throws Exception {
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
-        Files.createDirectories(archiveDir);
         layeredStore.createDirectory("a/b/c/d");
         layerManager.newTopLayer();
 

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreDeleteDirectoryTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreDeleteDirectoryTest.java
@@ -39,7 +39,7 @@ public class LayeredItemStoreDeleteDirectoryTest extends AbstractLayerDatabaseTe
 
     @Test
     public void should_not_delete_a_directory_with_content_in_another_layer() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
         Files.createDirectories(archiveDir);
         layeredStore.createDirectory("a/b/c/d");
@@ -52,7 +52,7 @@ public class LayeredItemStoreDeleteDirectoryTest extends AbstractLayerDatabaseTe
 
     @Test
     public void should_delete_empty_directory() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
         layeredStore.createDirectory("a/b/c/d");
 
@@ -78,7 +78,7 @@ public class LayeredItemStoreDeleteDirectoryTest extends AbstractLayerDatabaseTe
 
     @Test
     public void should_delete_directory_with_regular_file() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
         layeredStore.createDirectory("a/b/c/d");
         layeredStore.writeFile("a/b/c/test.txt", toInputStream("Hello world!", UTF_8));
@@ -107,7 +107,7 @@ public class LayeredItemStoreDeleteDirectoryTest extends AbstractLayerDatabaseTe
 
     @Test
     public void should_throw_cannot_delete_file_from_closed_layer() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
         layeredStore.createDirectory("a/b/c/d");
         layeredStore.writeFile("a/b/c/test.txt", toInputStream("Hello world!", UTF_8));

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreDeleteDirectoryTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreDeleteDirectoryTest.java
@@ -43,6 +43,7 @@ public class LayeredItemStoreDeleteDirectoryTest extends AbstractLayerDatabaseTe
     public void should_not_delete_a_directory_with_content_in_another_layer() throws Exception {
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
+        layeredStore.newTopLayer();
         layeredStore.createDirectory("a/b/c/d");
         layerManager.newTopLayer();
 
@@ -55,6 +56,7 @@ public class LayeredItemStoreDeleteDirectoryTest extends AbstractLayerDatabaseTe
     public void should_delete_empty_directory() throws Exception {
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
+        layeredStore.newTopLayer();
         layeredStore.createDirectory("a/b/c/d");
 
         // precondition: show database content
@@ -81,6 +83,7 @@ public class LayeredItemStoreDeleteDirectoryTest extends AbstractLayerDatabaseTe
     public void should_delete_directory_with_regular_file() throws Exception {
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
+        layeredStore.newTopLayer();
         layeredStore.createDirectory("a/b/c/d");
         layeredStore.writeFile("a/b/c/test.txt", toInputStream("Hello world!", UTF_8));
 
@@ -111,6 +114,7 @@ public class LayeredItemStoreDeleteDirectoryTest extends AbstractLayerDatabaseTe
         // Given
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
+        layeredStore.newTopLayer();
         layeredStore.createDirectory("a/b/c/d");
         layeredStore.writeFile("a/b/c/test.txt", toInputStream("Hello world!", UTF_8));
         Files.createDirectories(archiveDir);

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreDeleteFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreDeleteFileTest.java
@@ -63,6 +63,7 @@ public class LayeredItemStoreDeleteFileTest extends AbstractLayerDatabaseTest {
         // Given
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
+        layerManager.newTopLayer();
         layeredStore.createDirectory("a/b/c/d");
         layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!", UTF_8));
         layeredStore.writeFile("a/b/c/test2.txt", toInputStream("Hello world!", UTF_8));

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreDeleteFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreDeleteFileTest.java
@@ -39,7 +39,7 @@ public class LayeredItemStoreDeleteFileTest extends AbstractLayerDatabaseTest {
 
     @Test
     public void should_not_delete_a_file_in_a_closed_layer() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
         Files.createDirectories(archiveDir);
         layeredStore.createDirectory("a/b/c/d");
@@ -57,7 +57,7 @@ public class LayeredItemStoreDeleteFileTest extends AbstractLayerDatabaseTest {
 
     @Test
     public void should_delete_files_from_the_top_layer() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
         layeredStore.createDirectory("a/b/c/d");
         layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!", UTF_8));

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreDeleteFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreDeleteFileTest.java
@@ -33,51 +33,55 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 public class LayeredItemStoreDeleteFileTest extends AbstractLayerDatabaseTest {
 
     @BeforeEach
-    public void prepare() throws Exception {
+    public void setUp() throws Exception {
+        super.setUp();
         Files.createDirectories(stagingDir);
+        Files.createDirectories(archiveDir);
     }
 
     @Test
     public void should_not_delete_a_file_in_a_closed_layer() throws Exception {
+        // Given
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
-        Files.createDirectories(archiveDir);
+        var firstLayer = layerManager.newTopLayer();
         layeredStore.createDirectory("a/b/c/d");
         layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!", UTF_8));
         layeredStore.writeFile("a/b/c/test2.txt", toInputStream("Hello again!", UTF_8));
-        var firstLayer = layerManager.getTopLayer();
+
         layerManager.newTopLayer();
         assertFalse(firstLayer.isOpen());
 
-        assumeNotYetFixed("getLayer returns a new layer object. New layer objects are open but it should be closed in this scenario.");
-        assertThatThrownBy(() -> layeredStore.deleteFiles(List.of("a/b/c/d/test1.txt", "a/b/c/test2.txt")))
+        // When / Then
+        assertThatThrownBy(() -> firstLayer.deleteFiles(List.of("a/b/c/d/test1.txt", "a/b/c/test2.txt")))
             .isInstanceOf(IllegalStateException.class)
-            .hasMessageContaining("Cannot delete files from closed layer");
+            .hasMessageContaining("Layer is closed, but must be open for this operation");
     }
 
     @Test
     public void should_delete_files_from_the_top_layer() throws Exception {
+        // Given
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
         layeredStore.createDirectory("a/b/c/d");
         layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!", UTF_8));
         layeredStore.writeFile("a/b/c/test2.txt", toInputStream("Hello world!", UTF_8));
 
-        // precondition: show database content
+        // Precondition: database content
         var list1 = daoTestExtension.inTransaction(() ->
             db.getAllRecords().toList().stream().map(ItemRecord::getPath)
         );
         assertThat(list1).containsExactlyInAnyOrder("", "a", "a/b", "a/b/c", "a/b/c/d", "a/b/c/d/test1.txt", "a/b/c/test2.txt");
 
-        // method under test
+        // When
         layeredStore.deleteFiles(List.of("a/b/c/d/test1.txt", "a/b/c/test2.txt"));
 
-        // files are removed from the stagingDir
+        // Then: files are removed from the stagingDir
         Path layerDir = stagingDir.resolve(Path.of(String.valueOf((layerManager.getTopLayer().getId()))));
         assertThat(layerDir.resolve("a/b/c/d/test1.txt")).doesNotExist();
         assertThat(layerDir.resolve("a/b/c/test2.txt")).doesNotExist();
 
-        // files are removed from the database
+        // And: files are removed from the database
         var list2 = daoTestExtension.inTransaction(() ->
             db.getAllRecords().toList().stream().map(ItemRecord::getPath)
         );

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreExistsPathLikeTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreExistsPathLikeTest.java
@@ -34,7 +34,7 @@ public class LayeredItemStoreExistsPathLikeTest extends AbstractLayerDatabaseTes
 
     @Test
     public void should_return_a_shallow_list() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
         Files.createDirectories(archiveDir);
         layeredStore.createDirectory("a/b/c/d/e/f");

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreExistsPathLikeTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreExistsPathLikeTest.java
@@ -28,8 +28,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class LayeredItemStoreExistsPathLikeTest extends AbstractLayerDatabaseTest {
 
     @BeforeEach
-    public void prepare() throws Exception {
+    public void setUp() throws Exception {
+        super.setUp();
         Files.createDirectories(stagingDir);
+        Files.createDirectories(archiveDir);
     }
 
     @Test

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreExistsPathLikeTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreExistsPathLikeTest.java
@@ -38,7 +38,7 @@ public class LayeredItemStoreExistsPathLikeTest extends AbstractLayerDatabaseTes
     public void should_return_a_shallow_list() throws Exception {
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
-        Files.createDirectories(archiveDir);
+        layeredStore.newTopLayer();
         layeredStore.createDirectory("a/b/c/d/e/f");
         layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!", UTF_8));
         layeredStore.writeFile("a/b/c/test2.txt", toInputStream("Hello again!", UTF_8));

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreListDirectoryTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreListDirectoryTest.java
@@ -34,7 +34,7 @@ public class LayeredItemStoreListDirectoryTest extends AbstractLayerDatabaseTest
 
     @Test
     public void should_return_a_shallow_list() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
         Files.createDirectories(archiveDir);
         layeredStore.createDirectory("a/b/c/d/e/f");

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreListDirectoryTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreListDirectoryTest.java
@@ -38,7 +38,7 @@ public class LayeredItemStoreListDirectoryTest extends AbstractLayerDatabaseTest
     public void should_return_a_shallow_list() throws Exception {
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
-        Files.createDirectories(archiveDir);
+        layeredStore.newTopLayer();
         layeredStore.createDirectory("a/b/c/d/e/f");
         layeredStore.writeFile("a/b/c/d/test1.txt", toInputStream("Hello world!", UTF_8));
         layeredStore.writeFile("a/b/c/test2.txt", toInputStream("Hello again!", UTF_8));

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreListDirectoryTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreListDirectoryTest.java
@@ -28,8 +28,10 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 public class LayeredItemStoreListDirectoryTest extends AbstractLayerDatabaseTest {
 
     @BeforeEach
-    public void prepare() throws Exception {
+    public void setUp() throws Exception {
+        super.setUp();
         Files.createDirectories(stagingDir);
+        Files.createDirectories(archiveDir);
     }
 
     @Test

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreMoveDirectoryInternalTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreMoveDirectoryInternalTest.java
@@ -29,8 +29,10 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 public class LayeredItemStoreMoveDirectoryInternalTest extends AbstractLayerDatabaseTest {
 
     @BeforeEach
-    public void prepare() throws Exception {
+    public void setUp() throws Exception {
+        super.setUp();
         Files.createDirectories(stagingDir);
+        Files.createDirectories(archiveDir);
     }
 
     @Test
@@ -51,7 +53,6 @@ public class LayeredItemStoreMoveDirectoryInternalTest extends AbstractLayerData
 
     @Test
     public void should_not_move_dir_with_files_in_other_layer() throws Exception {
-        Files.createDirectories(archiveDir);
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
 
@@ -59,9 +60,6 @@ public class LayeredItemStoreMoveDirectoryInternalTest extends AbstractLayerData
         layeredStore.createDirectory("a/b/e/f");
         layeredStore.writeFile("a/b/e/f/test.txt", toInputStream("Hello world!", UTF_8));
         layerManager.newTopLayer();
-
-        // without this, a stack trace is logged from an archiving thread
-        Files.createDirectories(archiveDir);
 
         assertThatThrownBy(() -> layeredStore.moveDirectoryInternal("a/b/e/f", "a/b/c/d/x")).
             isInstanceOf(RuntimeException.class)

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreMoveDirectoryInternalTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreMoveDirectoryInternalTest.java
@@ -39,7 +39,7 @@ public class LayeredItemStoreMoveDirectoryInternalTest extends AbstractLayerData
     public void should_move_dir_with_file() throws Exception {
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
-
+        layeredStore.newTopLayer();
         layeredStore.createDirectory("a/b/c/d");
         layeredStore.createDirectory("a/b/e/f");
         layeredStore.writeFile("a/b/e/f/test.txt", toInputStream("Hello world!", UTF_8));
@@ -55,7 +55,7 @@ public class LayeredItemStoreMoveDirectoryInternalTest extends AbstractLayerData
     public void should_not_move_dir_with_files_in_other_layer() throws Exception {
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
-
+        layeredStore.newTopLayer();
         layeredStore.createDirectory("a/b/c/d");
         layeredStore.createDirectory("a/b/e/f");
         layeredStore.writeFile("a/b/e/f/test.txt", toInputStream("Hello world!", UTF_8));

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreMoveDirectoryInternalTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreMoveDirectoryInternalTest.java
@@ -35,7 +35,7 @@ public class LayeredItemStoreMoveDirectoryInternalTest extends AbstractLayerData
 
     @Test
     public void should_move_dir_with_file() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
 
         layeredStore.createDirectory("a/b/c/d");
@@ -52,7 +52,7 @@ public class LayeredItemStoreMoveDirectoryInternalTest extends AbstractLayerData
     @Test
     public void should_not_move_dir_with_files_in_other_layer() throws Exception {
         Files.createDirectories(archiveDir);
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
 
         layeredStore.createDirectory("a/b/c/d");

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreMoveDirectoryIntoTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreMoveDirectoryIntoTest.java
@@ -36,7 +36,8 @@ public class LayeredItemStoreMoveDirectoryIntoTest extends AbstractLayerDatabase
     }
 
     @BeforeEach
-    public void prepare() throws Exception {
+    public void setUp() throws Exception {
+        super.setUp();
         FileUtils.write(testDir.resolve("x/y/test1.txt").toFile(), "Hello world!", "UTF-8");
         FileUtils.write(testDir.resolve("x/test2.txt").toFile(), "Hello again!", "UTF-8");
     }

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreMoveDirectoryIntoTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreMoveDirectoryIntoTest.java
@@ -44,7 +44,7 @@ public class LayeredItemStoreMoveDirectoryIntoTest extends AbstractLayerDatabase
     @Test
     public void should_refuse_to_move_link() throws Exception {
         Files.createSymbolicLink(testDir.resolve("x/y/link"), testDir.resolve("x/test2.txt"));
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager, new StoreTxtContent());
         layeredStore.createDirectory("a/b");
 
@@ -55,7 +55,7 @@ public class LayeredItemStoreMoveDirectoryIntoTest extends AbstractLayerDatabase
 
     @Test
     public void should_add_directory_structure_and_files() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager, new StoreTxtContent());
         layeredStore.createDirectory("a/b");
 
@@ -80,7 +80,7 @@ public class LayeredItemStoreMoveDirectoryIntoTest extends AbstractLayerDatabase
 
     @Test
     public void should_create_parent_in_top_layer() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
         layeredStore.createDirectory("a/b");
         Files.createDirectories(archiveDir);
@@ -95,7 +95,7 @@ public class LayeredItemStoreMoveDirectoryIntoTest extends AbstractLayerDatabase
 
     @Test
     public void should_throw_parent_of_destination_does_not_exists() throws IOException {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
 
         assertThatThrownBy(() -> layeredStore.moveDirectoryInto(testDir.resolve("x"), "a/b/c")).
@@ -105,7 +105,7 @@ public class LayeredItemStoreMoveDirectoryIntoTest extends AbstractLayerDatabase
 
     @Test
     public void should_throw_destination_exists() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
 
         layeredStore.createDirectory("a/b/c");

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreMoveDirectoryIntoTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreMoveDirectoryIntoTest.java
@@ -15,7 +15,6 @@
  */
 package nl.knaw.dans.layerstore;
 
-import io.dropwizard.util.DirectExecutorService;
 import org.apache.commons.io.FileUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,6 +46,7 @@ public class LayeredItemStoreMoveDirectoryIntoTest extends AbstractLayerDatabase
         Files.createSymbolicLink(testDir.resolve("x/y/link"), testDir.resolve("x/test2.txt"));
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager, new StoreTxtContent());
+        layeredStore.newTopLayer();
         layeredStore.createDirectory("a/b");
 
         assertThatThrownBy(() -> layeredStore.moveDirectoryInto(testDir.resolve("x"), "a/b/c")).
@@ -58,6 +58,7 @@ public class LayeredItemStoreMoveDirectoryIntoTest extends AbstractLayerDatabase
     public void should_add_directory_structure_and_files() throws Exception {
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager, new StoreTxtContent());
+        layeredStore.newTopLayer();
         layeredStore.createDirectory("a/b");
 
         layeredStore.moveDirectoryInto(testDir.resolve("x"), "a/b/c");
@@ -83,6 +84,7 @@ public class LayeredItemStoreMoveDirectoryIntoTest extends AbstractLayerDatabase
     public void should_create_parent_in_top_layer() throws Exception {
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
+        layeredStore.newTopLayer();
         layeredStore.createDirectory("a/b");
         Files.createDirectories(archiveDir);
         layerManager.newTopLayer();
@@ -95,9 +97,10 @@ public class LayeredItemStoreMoveDirectoryIntoTest extends AbstractLayerDatabase
     }
 
     @Test
-    public void should_throw_parent_of_destination_does_not_exists() throws IOException {
+    public void should_throw_when_destination_parent_does_not_exist() throws IOException {
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
+        layeredStore.newTopLayer();
 
         assertThatThrownBy(() -> layeredStore.moveDirectoryInto(testDir.resolve("x"), "a/b/c")).
             isInstanceOf(IllegalArgumentException.class)
@@ -108,6 +111,7 @@ public class LayeredItemStoreMoveDirectoryIntoTest extends AbstractLayerDatabase
     public void should_throw_destination_exists() throws Exception {
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
+        layeredStore.newTopLayer();
 
         layeredStore.createDirectory("a/b/c");
 

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreReadFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreReadFileTest.java
@@ -47,6 +47,7 @@ public class LayeredItemStoreReadFileTest extends AbstractLayerDatabaseTest {
     public void should_read_content_from_stagingDir() throws Exception {
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
+        layeredStore.newTopLayer();
 
         var testContent = "Hello world!";
         layeredStore.writeFile("test.txt", toInputStream(testContent, UTF_8));
@@ -60,6 +61,7 @@ public class LayeredItemStoreReadFileTest extends AbstractLayerDatabaseTest {
     public void should_read_content_from_database_if_filter_applies() throws Exception {
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager, new StoreTxtContent());
+        layeredStore.newTopLayer();
 
         var testContent = "Hello world!";
         layeredStore.writeFile("test.txt", toInputStream(testContent, UTF_8));
@@ -73,6 +75,8 @@ public class LayeredItemStoreReadFileTest extends AbstractLayerDatabaseTest {
     public void should_throw_is_a_directory() throws Exception {
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager, new StoreTxtContent());
+        layeredStore.newTopLayer();
+
         layeredStore.createDirectory("a/b/c");
 
         assertThatThrownBy(() -> layeredStore.readFile("a/b")).
@@ -84,6 +88,7 @@ public class LayeredItemStoreReadFileTest extends AbstractLayerDatabaseTest {
     public void should_throw_no_such_file() throws IOException {
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager, new StoreTxtContent());
+        layeredStore.newTopLayer();
 
         assertThatThrownBy(() -> layeredStore.readFile("some.txt")).
             isInstanceOf(NoSuchFileException.class);

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreReadFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreReadFileTest.java
@@ -37,8 +37,10 @@ public class LayeredItemStoreReadFileTest extends AbstractLayerDatabaseTest {
     }
 
     @BeforeEach
-    public void prepare() throws Exception {
+    public void setUp() throws Exception {
+        super.setUp();
         Files.createDirectories(stagingDir);
+        Files.createDirectories(archiveDir);
     }
 
     @Test

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreReadFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreReadFileTest.java
@@ -43,7 +43,7 @@ public class LayeredItemStoreReadFileTest extends AbstractLayerDatabaseTest {
 
     @Test
     public void should_read_content_from_stagingDir() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
 
         var testContent = "Hello world!";
@@ -56,7 +56,7 @@ public class LayeredItemStoreReadFileTest extends AbstractLayerDatabaseTest {
 
     @Test
     public void should_read_content_from_database_if_filter_applies() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager, new StoreTxtContent());
 
         var testContent = "Hello world!";
@@ -69,7 +69,7 @@ public class LayeredItemStoreReadFileTest extends AbstractLayerDatabaseTest {
 
     @Test
     public void should_throw_is_a_directory() throws Exception {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager, new StoreTxtContent());
         layeredStore.createDirectory("a/b/c");
 
@@ -80,7 +80,7 @@ public class LayeredItemStoreReadFileTest extends AbstractLayerDatabaseTest {
 
     @Test
     public void should_throw_no_such_file() throws IOException {
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager, new StoreTxtContent());
 
         assertThatThrownBy(() -> layeredStore.readFile("some.txt")).

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreWriteFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreWriteFileTest.java
@@ -37,6 +37,7 @@ public class LayeredItemStoreWriteFileTest extends AbstractLayerDatabaseTest {
         Files.createDirectories(stagingDir);
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
+        layeredStore.newTopLayer();
 
         var testContent = "Hello world!";
         layeredStore.writeFile("test.txt", toInputStream(testContent, UTF_8));
@@ -53,6 +54,7 @@ public class LayeredItemStoreWriteFileTest extends AbstractLayerDatabaseTest {
         Files.createDirectories(stagingDir);
         var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager, new StoreTxtContent());
+        layeredStore.newTopLayer();
 
         var testContent = "Hello world!";
         layeredStore.writeFile("test.txt", toInputStream(testContent, UTF_8));
@@ -70,6 +72,7 @@ public class LayeredItemStoreWriteFileTest extends AbstractLayerDatabaseTest {
         Files.createDirectories(stagingDir);
         var layerManager = new LayerManagerImpl(stagingDir, new TarArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager, new StoreTxtContent());
+        layeredStore.newTopLayer();
 
         layeredStore.writeFile("test.txt", toInputStream("Hello world!", UTF_8));
         layeredStore.writeFile("test.txt", toInputStream("Hello again!", UTF_8));

--- a/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreWriteFileTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayeredItemStoreWriteFileTest.java
@@ -36,7 +36,7 @@ public class LayeredItemStoreWriteFileTest extends AbstractLayerDatabaseTest {
     @Test
     public void should_write_file_to_staging_dir_when_layer_is_open() throws Exception {
         Files.createDirectories(stagingDir);
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager);
 
         var testContent = "Hello world!";
@@ -52,7 +52,7 @@ public class LayeredItemStoreWriteFileTest extends AbstractLayerDatabaseTest {
     @Test
     public void should_write_copy_of_content_to_database_if_filter_applies() throws Exception {
         Files.createDirectories(stagingDir);
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager, new StoreTxtContent());
 
         var testContent = "Hello world!";
@@ -69,7 +69,7 @@ public class LayeredItemStoreWriteFileTest extends AbstractLayerDatabaseTest {
     @Test
     public void should_overwrite_content_in_the_database_if_filter_applies() throws Exception {
         Files.createDirectories(stagingDir);
-        var layerManager = new LayerManagerImpl(stagingDir, new TarArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new TarArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager, new StoreTxtContent());
 
         layeredStore.writeFile("test.txt", toInputStream("Hello world!", UTF_8));
@@ -88,7 +88,7 @@ public class LayeredItemStoreWriteFileTest extends AbstractLayerDatabaseTest {
     public void should_add_copies_to_the_database_if_filter_applies() throws Exception {
         Files.createDirectories(stagingDir);
         Files.createDirectories(archiveDir);
-        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectExecutorService());
+        var layerManager = new LayerManagerImpl(stagingDir, new ZipArchiveProvider(archiveDir), new DirectLayerArchiver());
         var layeredStore = new LayeredItemStore(db, layerManager, new StoreTxtContent());
 
         layeredStore.writeFile("test.txt", toInputStream("Hello world!", UTF_8));

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveItemIteratorTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveItemIteratorTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.layerstore;
+
+import nl.knaw.dans.lib.util.ZipUtil;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.HashSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ZipArchiveItemIteratorTest extends AbstractTestWithTestDir {
+
+    @Test
+    public void iterates_only_root_in_empty_zip_archive() throws Exception {
+        // Given
+        var zipFile = testDir.resolve("empty.zip");
+        Files.createDirectories(testDir.resolve("emptyDir"));
+        ZipUtil.zipDirectory(testDir.resolve("emptyDir"), zipFile, false);
+
+        var iterator = new ZipArchiveItemIterator(zipFile);
+
+        // When
+        var actualPaths = new HashSet<String>();
+        while (iterator.hasNext()) {
+            actualPaths.add(iterator.next().getPath());
+        }
+
+        // Then
+        assertThat(actualPaths).containsExactly("");
+    }
+
+
+    @Test
+    public void iterates_all_items_in_zip_archive() throws Exception {
+        // Given
+        var zipFile = testDir.resolve("test.zip");
+        var tempDir = testDir.resolve("zipInput");
+        FileUtils.writeStringToFile(tempDir.resolve("a/b/c/d/test1.txt").toFile(), "Hello world!", StandardCharsets.UTF_8);
+        FileUtils.writeStringToFile(tempDir.resolve("a/b/c/test2.txt").toFile(), "Hello again!", StandardCharsets.UTF_8);
+        FileUtils.writeStringToFile(tempDir.resolve("a/b/test3.txt").toFile(), "Hello once more!", StandardCharsets.UTF_8);
+        FileUtils.writeStringToFile(tempDir.resolve("a/test4.txt").toFile(), "Hello for the last time!", StandardCharsets.UTF_8);
+        ZipUtil.zipDirectory(tempDir, zipFile, false);
+
+        var iterator = new ZipArchiveItemIterator(zipFile);
+
+        // When
+        var actualPaths = new HashSet<String>();
+        while (iterator.hasNext()) {
+            actualPaths.add(iterator.next().getPath());
+        }
+
+        // Then
+        assertThat(actualPaths).containsExactlyInAnyOrder(
+            "",
+            "a/",
+            "a/b/",
+            "a/b/c/",
+            "a/b/c/d/",
+            "a/b/c/d/test1.txt",
+            "a/b/c/test2.txt",
+            "a/b/test3.txt",
+            "a/test4.txt"
+        );
+    }
+}

--- a/src/test/java/nl/knaw/dans/layerstore/ZipArchiveListAllItemsTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/ZipArchiveListAllItemsTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.layerstore;
+
+import nl.knaw.dans.lib.util.ZipUtil;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.HashSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ZipArchiveListAllItemsTest extends AbstractTestWithTestDir {
+
+    @Test
+    public void iterates_only_root_in_empty_zip_archive() throws Exception {
+        // Given
+        var zipFile = testDir.resolve("empty.zip");
+        Files.createDirectories(testDir.resolve("emptyDir"));
+        ZipUtil.zipDirectory(testDir.resolve("emptyDir"), zipFile, false);
+
+        var zipArchive = new ZipArchive(zipFile);
+        var iterator = zipArchive.listAllItems();
+
+        // When
+        var actualPaths = new HashSet<String>();
+        while (iterator.hasNext()) {
+            actualPaths.add(iterator.next().getPath());
+        }
+
+        // Then
+        assertThat(actualPaths).containsExactly("");
+    }
+
+
+    @Test
+    public void iterates_all_items_in_zip_archive() throws Exception {
+        // Given
+        var zipFile = testDir.resolve("test.zip");
+        var tempDir = testDir.resolve("zipInput");
+        FileUtils.writeStringToFile(tempDir.resolve("a/b/c/d/test1.txt").toFile(), "Hello world!", StandardCharsets.UTF_8);
+        FileUtils.writeStringToFile(tempDir.resolve("a/b/c/test2.txt").toFile(), "Hello again!", StandardCharsets.UTF_8);
+        FileUtils.writeStringToFile(tempDir.resolve("a/b/test3.txt").toFile(), "Hello once more!", StandardCharsets.UTF_8);
+        FileUtils.writeStringToFile(tempDir.resolve("a/test4.txt").toFile(), "Hello for the last time!", StandardCharsets.UTF_8);
+        ZipUtil.zipDirectory(tempDir, zipFile, false);
+
+        var zipArchive = new ZipArchive(zipFile);
+        zipArchive.archiveFrom(tempDir);
+        var iterator = zipArchive.listAllItems();
+
+        // When
+        var actualPaths = new HashSet<String>();
+        while (iterator.hasNext()) {
+            actualPaths.add(iterator.next().getPath());
+        }
+
+        // Then
+        assertThat(actualPaths).containsExactlyInAnyOrder(
+            "",
+            "a/",
+            "a/b/",
+            "a/b/c/",
+            "a/b/c/d/",
+            "a/b/c/d/test1.txt",
+            "a/b/c/test2.txt",
+            "a/b/test3.txt",
+            "a/test4.txt"
+        );
+    }
+}


### PR DESCRIPTION
Fixes DD-2009

# Description of changes
* Refactored a number of interface methods that took a `path` to a layer, which was in fact always a layer ID. These methods now take a `layerId` of type `long`.
* Added methods to retrieve the list of layer IDs from the database and from the layer as it exists in storage.
* Added `nl.knaw.dans.layerstore.LayeredItemStore#checkSameLayerIdsFoundOnStorageAsInDatabase` which throws an IllegalStateException if the DB is inconsitent with storage.



# How to test


# Related PRs 
(Add links)
* 

# Notify
@DANS-KNAW/core-systems
