### PR TITLE
DD-2244 Prevent early reading attempt of remote Data Archive

### DIFF
--- a/src/main/java/nl/knaw/dans/layerstore/ArchiveProvider.java
+++ b/src/main/java/nl/knaw/dans/layerstore/ArchiveProvider.java
@@ -27,10 +27,10 @@ public interface ArchiveProvider {
      * Create a new {@link Archive} instance for the given layer ID.
      *
      * @param layerId the layer ID
+     * @param exists the archive file already exists
      * @return the new archive
      */
-    Archive createArchive(long layerId);
-
+    Archive createArchive(long layerId, boolean exists);
 
     /**
      * Check if an archive exists at the given path.
@@ -39,7 +39,6 @@ public interface ArchiveProvider {
      * @return true if the archive exists, false otherwise
      */
     boolean exists(long layerId);
-
 
     /**
      * List all archived layer IDs.

--- a/src/main/java/nl/knaw/dans/layerstore/DmfTarArchiveProvider.java
+++ b/src/main/java/nl/knaw/dans/layerstore/DmfTarArchiveProvider.java
@@ -29,8 +29,8 @@ public class DmfTarArchiveProvider implements ArchiveProvider {
     private final SshRunner sshRunner;
 
     @Override
-    public Archive createArchive(long layerId) {
-        return new DmfTarArchive(dmfTarRunner, layerId + ".dmftar", exists(layerId));
+    public Archive createArchive(long layerId, boolean exists) {
+        return new DmfTarArchive(dmfTarRunner, layerId + ".dmftar", exists);
     }
 
     @Override

--- a/src/main/java/nl/knaw/dans/layerstore/LayerManagerImpl.java
+++ b/src/main/java/nl/knaw/dans/layerstore/LayerManagerImpl.java
@@ -126,6 +126,14 @@ public class LayerManagerImpl implements LayerManager {
 
     @Override
     public void archive(Layer layer, boolean overwrite) {
+        /*
+         * N.B. for DmfTarArchiveProvider we need to check the existence here, instead of relying on DmfTarArchive.archive to do that. The reason is that the "archived" property of DmfTarArchive is
+         * set to false when creating a new top layer. In cases where the archive file somehow exists anyway, this will not be detected by DmfTarArchive.archive, and the existing archive file will be
+         * overwritten. If feasible, we should probably try to hide direct access to the Layer interface by users of the library and instead force them to use LayerManager for all operations.
+         */
+        if (!overwrite && archiveProvider.exists(layer.getId())) {
+            throw new IllegalArgumentException("Layer with id " + layer.getId() + " is already archived");
+        }
         layerArchiver.archive(layer, overwrite);
     }
 

--- a/src/main/java/nl/knaw/dans/layerstore/LayerManagerImpl.java
+++ b/src/main/java/nl/knaw/dans/layerstore/LayerManagerImpl.java
@@ -113,6 +113,9 @@ public class LayerManagerImpl implements LayerManager {
                 oldTopLayer.close();
             }
             log.debug("Scheduling old top layer with id {} for archiving", oldTopLayer.getId());
+            if (archiveProvider.exists(oldTopLayer.getId())) {
+                throw new IllegalStateException("Old top layer with id " + oldTopLayer.getId() + " is already archived");
+            }
             archive(oldTopLayer, false);
         }
         else {

--- a/src/main/java/nl/knaw/dans/layerstore/LayerManagerImpl.java
+++ b/src/main/java/nl/knaw/dans/layerstore/LayerManagerImpl.java
@@ -33,8 +33,8 @@ import java.util.regex.Pattern;
 @Slf4j
 public class LayerManagerImpl implements LayerManager {
     /**
-     * Pattern for valid layer names. Layer names are Unix timestamps with the optional suffix '.closed' or '.partial', for closed or partially archived layers.
-     * Current timestamps have 13 digits. After November 2286, timestamps will have 14 digits.
+     * Pattern for valid layer names. Layer names are Unix timestamps with the optional suffix '.closed' or '.partial', for closed or partially archived layers. Current timestamps have 13 digits.
+     * After November 2286, timestamps will have 14 digits.
      */
     private static final Pattern validLayerNamePattern = Pattern.compile("^\\d{13,}(\\.(closed|partial))?$");
 
@@ -48,14 +48,27 @@ public class LayerManagerImpl implements LayerManager {
     private Layer topLayer;
 
     /**
-     * Creates a new LayerManagerImpl.
+     * Creates a new LayerManagerImpl and validates the archive root.
      *
-     * @param stagingRoot     the root directory for staging layers.
-     * @param archiveProvider the archive provider to use.
-     * @param layerArchiver   the layer archiver to use.
-     * @throws IOException if the staging root directory cannot be created.
+     * @param stagingRoot     the root directory for staging layers; must not be null.
+     * @param archiveProvider the provider responsible for managing archives; must not be null.
+     * @param layerArchiver   the archiver used to handle layer archiving; must not be null.
+     * @throws IOException if the staging root directory cannot be created or accessed.
      */
     public LayerManagerImpl(@NonNull Path stagingRoot, @NonNull ArchiveProvider archiveProvider, @NonNull LayerArchiver layerArchiver) throws IOException {
+        this(stagingRoot, archiveProvider, layerArchiver, true);
+    }
+
+    /**
+     * Creates a new LayerManagerImpl.
+     *
+     * @param stagingRoot         the root directory for staging layers.
+     * @param archiveProvider     the archive provider to use.
+     * @param layerArchiver       the layer archiver to use.
+     * @param validateArchiveRoot validate that the directory containing the archived layers does not contain other files
+     * @throws IOException if the staging root directory cannot be created.
+     */
+    public LayerManagerImpl(@NonNull Path stagingRoot, @NonNull ArchiveProvider archiveProvider, @NonNull LayerArchiver layerArchiver, boolean validateArchiveRoot) throws IOException {
         this.stagingRoot = stagingRoot;
         this.layerArchiver = layerArchiver;
         this.archiveProvider = archiveProvider;
@@ -63,13 +76,15 @@ public class LayerManagerImpl implements LayerManager {
             Files.createDirectories(this.stagingRoot);
         }
         validateStagingRoot();
-        this.archiveProvider.validateRoot();
+        if (validateArchiveRoot) {
+            this.archiveProvider.validateRoot();
+        }
         try (var pathStream = Files.list(this.stagingRoot)) {
             pathStream
                 .map(StagingDir::new)
                 .max(Comparator.comparingLong(StagingDir::getId))
                 .ifPresent(maxDir -> {
-                        topLayer = new LayerImpl(maxDir.getId(), maxDir, this.archiveProvider.createArchive(maxDir.getId()));
+                        topLayer = new LayerImpl(maxDir.getId(), maxDir, this.archiveProvider.createArchive(maxDir.getId(), false));
                     }
                 );
         }
@@ -90,7 +105,7 @@ public class LayerManagerImpl implements LayerManager {
         log.debug("Creating new top layer with id {}", id);
         var stagingDir = stagingRoot.resolve(Long.toString(id));
         Files.createDirectories(stagingDir);
-        var newLayer = new LayerImpl(id, new StagingDir(stagingDir), archiveProvider.createArchive(id));
+        var newLayer = new LayerImpl(id, new StagingDir(stagingDir), archiveProvider.createArchive(id, false));
         topLayer = newLayer;
 
         if (oldTopLayer != null) {
@@ -129,8 +144,9 @@ public class LayerManagerImpl implements LayerManager {
         }
         else {
             var stagingDir = new StagingDir(stagingRoot, id);
-            if (stagingDir.isStaged() || archiveProvider.exists(id)) {
-                return new LayerImpl(id, stagingDir, archiveProvider.createArchive(id));
+            boolean archiveFileExists = archiveProvider.exists(id);
+            if (stagingDir.isStaged() || archiveFileExists) {
+                return new LayerImpl(id, stagingDir, archiveProvider.createArchive(id, archiveFileExists));
             }
             else {
                 throw new IllegalArgumentException("No layer found with id " + id);

--- a/src/main/java/nl/knaw/dans/layerstore/TarArchiveProvider.java
+++ b/src/main/java/nl/knaw/dans/layerstore/TarArchiveProvider.java
@@ -30,7 +30,7 @@ public class TarArchiveProvider implements ArchiveProvider {
     private final Path archiveRoot;
 
     @Override
-    public Archive createArchive(long layerId) {
+    public Archive createArchive(long layerId, boolean exists) {
         return new TarArchive(archiveRoot.resolve(layerId + ".tar"));
     }
 

--- a/src/main/java/nl/knaw/dans/layerstore/ZipArchiveProvider.java
+++ b/src/main/java/nl/knaw/dans/layerstore/ZipArchiveProvider.java
@@ -29,7 +29,7 @@ public class ZipArchiveProvider implements ArchiveProvider {
     private final Path archiveRoot;
 
     @Override
-    public Archive createArchive(long layerId) {
+    public Archive createArchive(long layerId, boolean exists) {
         return new ZipArchive(archiveRoot.resolve(layerId + ".zip"));
     }
 

--- a/src/test/java/nl/knaw/dans/layerstore/LayerManagerConstructorTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerManagerConstructorTest.java
@@ -16,12 +16,16 @@
 package nl.knaw.dans.layerstore;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.nio.file.Files;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class LayerManagerConstructorTest extends AbstractLayerDatabaseTest {
 
@@ -105,5 +109,42 @@ public class LayerManagerConstructorTest extends AbstractLayerDatabaseTest {
         assertThat(layerManager.getTopLayer()).isNotNull();
         assertThat(layerManager.getTopLayer().getId()).isEqualTo(existingLayerId);
         assertThat(layerManager.getTopLayer().getState()).isEqualTo(Layer.State.CLOSED);
+    }
+
+    @Test
+    public void should_validate_archive_root_by_default() throws IOException {
+        var archiveProvider = Mockito.mock(ArchiveProvider.class);
+        new LayerManagerImpl(stagingRoot, archiveProvider, new DirectLayerArchiver());
+        verify(archiveProvider, times(1)).validateRoot();
+    }
+
+    @Test
+    public void should_not_validate_archive_root_if_validateArchiveRoot_is_false() throws IOException {
+        var archiveProvider = Mockito.mock(ArchiveProvider.class);
+        new LayerManagerImpl(stagingRoot, archiveProvider, new DirectLayerArchiver(), false);
+        verify(archiveProvider, never()).validateRoot();
+    }
+
+    @Test
+    public void should_throw_if_archive_root_validation_fails_and_validateArchiveRoot_is_true() throws IOException {
+        Files.createDirectories(archiveRoot);
+        var invalidFile = "invalid-file";
+        Files.createFile(archiveRoot.resolve(invalidFile));
+
+        assertThatThrownBy(() -> new LayerManagerImpl(stagingRoot, new ZipArchiveProvider(archiveRoot), new DirectLayerArchiver(), true))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("Archive root")
+            .hasMessageContaining("contains illegal files")
+            .hasMessageContaining(invalidFile);
+    }
+
+    @Test
+    public void should_not_throw_if_archive_root_validation_fails_but_validateArchiveRoot_is_false() throws IOException {
+        Files.createDirectories(archiveRoot);
+        var invalidFile = "invalid-file";
+        Files.createFile(archiveRoot.resolve(invalidFile));
+
+        // Should not throw
+        new LayerManagerImpl(stagingRoot, new ZipArchiveProvider(archiveRoot), new DirectLayerArchiver(), false);
     }
 }

--- a/src/test/java/nl/knaw/dans/layerstore/LayerManagerNewTopLayerTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerManagerNewTopLayerTest.java
@@ -43,7 +43,7 @@ public class LayerManagerNewTopLayerTest extends AbstractCapturingTest {
 
         // When / Then
         assertThatThrownBy(layerManager::newTopLayer)
-            .isInstanceOf(IllegalArgumentException.class)
+            .isInstanceOf(IllegalStateException.class)
             .hasMessageContaining("already archived");
     }
 

--- a/src/test/java/nl/knaw/dans/layerstore/LayerManagerNewTopLayerTest.java
+++ b/src/test/java/nl/knaw/dans/layerstore/LayerManagerNewTopLayerTest.java
@@ -20,6 +20,8 @@ import org.junit.jupiter.api.Test;
 import javax.validation.constraints.NotNull;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -54,8 +56,8 @@ public class LayerManagerNewTopLayerTest extends AbstractCapturingTest {
             }
 
             @Override
-            public java.util.List<String> listFiles(String flags) {
-                return java.util.Collections.emptyList();
+            public List<String> listFiles(String flags) {
+                return Collections.emptyList();
             }
         };
     }


### PR DESCRIPTION
Fixes DD-2244

# Description of changes
Not really related to the core of DD-2244 but the problem serviced when trying to test DD-2244. `dd-data-vault` performs some start-up checks that need access to Data Archive. When Data Archive is down the start up therefore fails. To work around this you can turn off most of these checks. This PR adds an extra option: you can now instruct the constructor of `LayerManagerImpl` to skip validation of the archive root: https://github.com/DANS-KNAW/dans-layer-store-lib/pull/19/changes#diff-60d04c66a1f3b5f2396e82d0ba5c7764f786bf133676d12d192a64bf602e34bcL58 .

However, it turned out that even so, the code will try to find out if an existing layer file is present for a new top layer. Since this is strictly not necessary (the top layer should never exist as an archive at creation time) `createArchive` was changed to take this information as a boolean from the caller ( https://github.com/DANS-KNAW/dans-layer-store-lib/pull/19/changes#diff-2917d6860b2e91a5c3d61ef9276881a44a87310f4384da58701e84f4e2ae3085L32 ) The code that creates a new top layer will now just assert that the archive for the layer does not exist: https://github.com/DANS-KNAW/dans-layer-store-lib/pull/19/changes#diff-60d04c66a1f3b5f2396e82d0ba5c7764f786bf133676d12d192a64bf602e34bcL72. When creating an Archive object for another layer, the existence check is still performed: https://github.com/DANS-KNAW/dans-layer-store-lib/pull/19/changes#diff-60d04c66a1f3b5f2396e82d0ba5c7764f786bf133676d12d192a64bf602e34bcL132. 

When archiving the old top layer in `newTopLayer`, the existence check is now done in the calling code: 
https://github.com/DANS-KNAW/dans-layer-store-lib/pull/19/changes#diff-60d04c66a1f3b5f2396e82d0ba5c7764f786bf133676d12d192a64bf602e34bcR116

# Notify
@DANS-KNAW/core-systems
